### PR TITLE
Observe HTTP header stats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ lazy val httpclient = project.in(file("faunadb-httpclient"))
     autoScalaLibrary := false,
     compileOrder := CompileOrder.JavaThenScala,
     javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "+q", "-v", "-a"),
     apiURL := Some(url("http://faunadb.github.io/faunadb-jvm/faunadb-httpclient/api/")),
     (javacOptions in doc) := Seq("-source", "1.7",
       "-link", "http://docs.oracle.com/javase/7/docs/api/",
@@ -44,7 +45,12 @@ lazy val httpclient = project.in(file("faunadb-httpclient"))
       "io.dropwizard.metrics" % "metrics-core" % metricsVersion,
       "org.slf4j" % "slf4j-api" % "1.7.7",
       "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
-      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+      "org.apache.commons" % "commons-lang3" % "3.4" % "test",
+      "ch.qos.logback" % "logback-classic" % "1.1.3" % "test",
+      "com.novocode" % "junit-interface" % "0.11" % "test",
+      "org.hamcrest" % "hamcrest-library" % "1.3" % "test",
+      "junit" % "junit" % "4.12" % "test"
     )
   )
 
@@ -54,6 +60,7 @@ lazy val scala = project.in(file("faunadb-scala"))
     name := "faunadb-scala",
     scalaVersion := "2.11.7",
     libraryDependencies ++= Seq(
+      "com.google.code.findbugs" % "jsr305" % "3.0.1",
       "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.3",
       "ch.qos.logback" % "logback-classic" % "1.1.3" % "test",
@@ -87,7 +94,7 @@ lazy val java = project.in(file("faunadb-java"))
     autoScalaLibrary := false,
     compileOrder := CompileOrder.JavaThenScala,
     javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),
-    testOptions += Tests.Argument(TestFrameworks.JUnit, "+q", "-v"),
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "+q", "-v", "-a"),
     apiURL := Some(url("http://faunadb.github.io/faunadb-jvm/faunadb-java/api/")),
     (javacOptions in doc) := Seq("-source", "1.7",
       "-link", "http://docs.oracle.com/javase/7/docs/api/",

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,17 @@ lazy val commonSettings = Seq(
   )
 )
 
+lazy val javaTestSettings = Seq(
+  testOptions += Tests.Argument(TestFrameworks.JUnit, "+q", "-v", "-a"),
+  libraryDependencies ++= Seq(
+    "org.apache.commons" % "commons-lang3" % "3.4" % "test",
+    "ch.qos.logback" % "logback-classic" % "1.1.3" % "test",
+    "com.novocode" % "junit-interface" % "0.11" % "test",
+    "org.hamcrest" % "hamcrest-library" % "1.3" % "test",
+    "junit" % "junit" % "4.12" % "test"
+  )
+)
+
 lazy val root = (project in file("."))
   .settings(commonSettings: _*)
   .settings(
@@ -25,13 +36,13 @@ lazy val root = (project in file("."))
 
 lazy val httpclient = project.in(file("faunadb-httpclient"))
   .settings(commonSettings: _*)
+  .settings(javaTestSettings: _*)
   .settings(
     name := "faunadb-httpclient",
     crossPaths := false,
     autoScalaLibrary := false,
     compileOrder := CompileOrder.JavaThenScala,
     javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),
-    testOptions += Tests.Argument(TestFrameworks.JUnit, "+q", "-v", "-a"),
     apiURL := Some(url("http://faunadb.github.io/faunadb-jvm/faunadb-httpclient/api/")),
     (javacOptions in doc) := Seq("-source", "1.7",
       "-link", "http://docs.oracle.com/javase/7/docs/api/",
@@ -45,12 +56,7 @@ lazy val httpclient = project.in(file("faunadb-httpclient"))
       "io.dropwizard.metrics" % "metrics-core" % metricsVersion,
       "org.slf4j" % "slf4j-api" % "1.7.7",
       "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
-      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-      "org.apache.commons" % "commons-lang3" % "3.4" % "test",
-      "ch.qos.logback" % "logback-classic" % "1.1.3" % "test",
-      "com.novocode" % "junit-interface" % "0.11" % "test",
-      "org.hamcrest" % "hamcrest-library" % "1.3" % "test",
-      "junit" % "junit" % "4.12" % "test"
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
     )
   )
 
@@ -88,13 +94,13 @@ lazy val scala = project.in(file("faunadb-scala"))
 
 lazy val java = project.in(file("faunadb-java"))
   .settings(commonSettings: _*)
+  .settings(javaTestSettings: _*)
   .settings(
     name := "faunadb-java",
     crossPaths := false,
     autoScalaLibrary := false,
     compileOrder := CompileOrder.JavaThenScala,
     javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),
-    testOptions += Tests.Argument(TestFrameworks.JUnit, "+q", "-v", "-a"),
     apiURL := Some(url("http://faunadb.github.io/faunadb-jvm/faunadb-java/api/")),
     (javacOptions in doc) := Seq("-source", "1.7",
       "-link", "http://docs.oracle.com/javase/7/docs/api/",
@@ -104,13 +110,7 @@ lazy val java = project.in(file("faunadb-java"))
     ),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-q"),
     libraryDependencies ++= Seq(
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % jacksonVersion,
-      "ch.qos.logback" % "logback-classic" % "1.1.3" % "test",
-      "org.apache.commons" % "commons-lang3" % "3.4" % "test",
-      "org.yaml" % "snakeyaml" % "1.14" % "test",
-      "com.novocode" % "junit-interface" % "0.11" % "test",
-      "org.hamcrest" % "hamcrest-library" % "1.3" % "test",
-      "junit" % "junit" % "4.12" % "test"
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % jacksonVersion
     )
   )
   .dependsOn(httpclient)

--- a/faunadb-httpclient/src/main/java/com/faunadb/httpclient/Connection.java
+++ b/faunadb-httpclient/src/main/java/com/faunadb/httpclient/Connection.java
@@ -5,6 +5,7 @@ import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.ning.http.client.*;
@@ -17,9 +18,9 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The HTTP Connection adapter for FaunaDB clients.
@@ -143,6 +144,72 @@ public class Connection {
       return new Connection(root, authToken, c, r);
     }
   }
+
+  private static String StatHeaderPrefix = "fauna-request-reported";
+
+  private static class StatHeader {
+    private String header;
+    private String stat;
+
+    static StatHeader of(String header) {
+      return new StatHeader(header);
+    }
+
+    String header() {
+      return header;
+    }
+
+    String stat() {
+      return stat;
+    }
+
+    StatHeader(String header) {
+      this.header = header;
+      this.stat = StatHeaderPrefix + "-" + header.substring(2).toLowerCase(); // strip X-
+    }
+  }
+
+  private static StatHeader XIOReadTime = StatHeader.of("X-IO-Read-Time");
+  private static StatHeader XIOWriteTime = StatHeader.of("X-IO-Write-Time");
+  private static StatHeader XHttpRequestProcessingTime = StatHeader.of("X-HTTP-Request-Processing-Time");
+  private static StatHeader XKeyCachedGet = StatHeader.of("X-Key-Cached-Get");
+  private static StatHeader XTokenCachedGet = StatHeader.of("X-Token-Cached-Get");
+  private static StatHeader XIndexCachedGet = StatHeader.of("X-Index-Cached-Get");
+  private static StatHeader XIndexCachedGetBySource = StatHeader.of("X-Index-Cached-GetBySource");
+  private static StatHeader XIndexCachedGetByName = StatHeader.of("X-Index-Cached-GetByName");
+  private static StatHeader XKeysLoad = StatHeader.of("X-Keys-Load");
+  private static StatHeader XKeysReload = StatHeader.of("X-Keys-Reload");
+  private static StatHeader XSchemaLoad = StatHeader.of("X-Schema-Load");
+  private static StatHeader XSchemaReload = StatHeader.of("X-Schema-Reload");
+
+  private static ImmutableSet<StatHeader> TimingHeaders = ImmutableSet.of(
+    XIOReadTime, XIOWriteTime, XHttpRequestProcessingTime, XKeyCachedGet, XTokenCachedGet,
+    XIndexCachedGet, XIndexCachedGetBySource, XIndexCachedGetByName
+  );
+
+  private static StatHeader XIOStackSize = StatHeader.of("X-IO-Stack-Size");
+  private static StatHeader XIOTransactionCount = StatHeader.of("X-IO-Transaction-Count");
+  private static StatHeader XIOReadOps = StatHeader.of("X-IO-Read-Ops");
+  private static StatHeader XIORemoveOps = StatHeader.of("X-IO-Remove-Ops");
+  private static StatHeader XIOInsertOps = StatHeader.of("X-IO-Insert-Ops");
+  private static StatHeader XIOCounterOps = StatHeader.of("X-IO-Counter-Ops");
+  private static StatHeader XIOColumnsRead = StatHeader.of("X-IO-Columns-Read");
+  private static StatHeader XIOColumnsWritten = StatHeader.of("X-IO-Columns-Written");
+  private static StatHeader XIOCounterColumnsWritten = StatHeader.of("X-IO-CounterColumns-Written");
+  private static StatHeader XIOTombstonesRead = StatHeader.of("X-IO-Tombstones-Read");
+  private static StatHeader XLockTableAttempts = StatHeader.of("X-LockTable-Attempts");
+  private static StatHeader XLockTableSuccesses = StatHeader.of("X-LockTable-Successes");
+  private static StatHeader XLockTableUnlocks = StatHeader.of("X-LockTable-Unlocks");
+  private static StatHeader XLockTableFailuresStale = StatHeader.of("X-LockTable-Failures-Stale");
+  private static StatHeader XLockTableRetries = StatHeader.of("X-LockTable-Retries");
+  private static StatHeader XLockTableFailures = StatHeader.of("X-LockTable-Failures");
+  private static StatHeader XLockTableResets = StatHeader.of("X-LockTable-Resets");
+
+  private static ImmutableSet<StatHeader> HistogramHeaders = ImmutableSet.of(
+    XIOStackSize, XIOTransactionCount, XIOReadOps, XIORemoveOps, XIOInsertOps, XIOCounterOps,
+    XIOColumnsRead, XIOColumnsWritten, XIOCounterColumnsWritten, XIOTombstonesRead,
+    XLockTableAttempts, XLockTableSuccesses, XLockTableUnlocks, XLockTableFailuresStale, XLockTableRetries, XLockTableFailures, XLockTableResets
+  );
 
   private static String XFaunaDBHost = "X-FaunaDB-Host";
   private static String XFaunaDBBuild = "X-FaunaDB-Build";
@@ -275,8 +342,9 @@ public class Connection {
         @Override
         public Response onCompleted(Response response) throws Exception {
           ctx.stop();
-          rv.set(response);
+          recordStatsHeaders(request, response);
           logSuccess(request, response);
+          rv.set(response);
           return response;
         }
       });
@@ -286,6 +354,40 @@ public class Connection {
 
   private String mkUrl(String path) throws MalformedURLException {
     return new URL(faunaRoot, path).toString();
+  }
+
+  private void recordStatsHeaders(Request request, Response response) {
+    for (StatHeader header : TimingHeaders) {
+      String stat = response.getHeader(header.header());
+      recordTimingHeader(stat, header.stat());
+    }
+
+    for (StatHeader header : HistogramHeaders) {
+      String stat = response.getHeader(header.header());
+      recordHistogramHeader(stat, header.stat());
+    }
+  }
+
+  private void recordHistogramHeader(String stat, String key) {
+    if (stat != null) {
+      try {
+        long parsed = Long.parseLong(stat);
+        registry.histogram(key).update(parsed);
+      } catch (NumberFormatException ex) {
+        log.debug("Could not parse histogram header value: " + stat + " for stat key: " + key);
+      }
+    }
+  }
+
+  private void recordTimingHeader(String stat, String key) {
+    if (stat != null) {
+      try {
+        long parsed = Long.parseLong(stat);
+        registry.timer(key).update(parsed, TimeUnit.MILLISECONDS);
+      } catch (NumberFormatException ex) {
+        log.debug("Could not parse timing header value: " + stat + " for stat key: " + key);
+      }
+    }
   }
 
   private void logSuccess(Request request, Response response) throws IOException {

--- a/faunadb-httpclient/src/main/java/com/faunadb/httpclient/Connection.java
+++ b/faunadb-httpclient/src/main/java/com/faunadb/httpclient/Connection.java
@@ -184,7 +184,8 @@ public class Connection {
 
   private static ImmutableSet<StatHeader> TimingHeaders = ImmutableSet.of(
     XIOReadTime, XIOWriteTime, XHttpRequestProcessingTime, XKeyCachedGet, XTokenCachedGet,
-    XIndexCachedGet, XIndexCachedGetBySource, XIndexCachedGetByName
+    XIndexCachedGet, XIndexCachedGetBySource, XIndexCachedGetByName,
+    XKeysLoad, XKeysReload, XSchemaLoad, XSchemaReload
   );
 
   private static StatHeader XIOStackSize = StatHeader.of("X-IO-Stack-Size");

--- a/faunadb-httpclient/src/test/java/com/faunadb/httpclient/ConnectionSpec.java
+++ b/faunadb-httpclient/src/test/java/com/faunadb/httpclient/ConnectionSpec.java
@@ -1,0 +1,95 @@
+package com.faunadb.httpclient;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.ning.http.client.Response;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.SortedMap;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class ConnectionSpec {
+  static ImmutableMap<String, String> config = getConfig();
+  static final ObjectMapper json = new ObjectMapper();
+
+  static String testDbName = "faunadb-httpclient-test-" + RandomStringUtils.randomAlphanumeric(8);
+
+  // Cargo culted duplicated test code
+  static ImmutableMap<String, String> getConfig() {
+    String rootKey = System.getenv("FAUNA_ROOT_KEY");
+    if (rootKey == null) throw new RuntimeException("FAUNA_ROOT_KEY must be defined to run tests");
+
+    String domain = System.getenv("FAUNA_DOMAIN");
+    if (domain == null) domain = "rest.faunadb.com";
+
+    String scheme = System.getenv("FAUNA_SCHEME");
+    if (scheme == null) scheme = "https";
+
+    String port = System.getenv("FAUNA_PORT");
+    if (port == null) port = "443";
+
+    return ImmutableMap.<String, String>builder()
+      .put("root_token", rootKey)
+      .put("root_url", scheme + "://" + domain + ":" + port)
+      .build();
+  }
+
+  static Connection mkConnection(MetricRegistry registry) throws IOException {
+    return Connection.builder()
+      .withFaunaRoot(config.get("root_url"))
+      .withAuthToken(config.get("root_token"))
+      .withMetrics(registry)
+      .build();
+  }
+
+  @Test
+  public void testStatsRecording() throws IOException, ExecutionException, InterruptedException {
+    MetricRegistry registry = new MetricRegistry();
+    Connection conn = mkConnection(registry);
+
+    // this is easier than just manipulating the AST :(
+    JsonNode q1 = json.readTree("{\n" +
+      "    \"q\": {\n" +
+      "        \"create\": {\n" +
+      "            \"@ref\": \"databases\"\n" +
+      "        },\n" +
+      "        \"params\": {\n" +
+      "            \"object\": {\n" +
+      "                \"name\": \""+testDbName+"\"\n" +
+      "            }\n" +
+      "        }\n" +
+      "    }\n" +
+      "}");
+
+    Response resp = conn.post("/", q1).get();
+
+    SortedMap<String, Histogram> histograms = registry.getHistograms();
+    assertThat(histograms.get("fauna-request-reported-io-columns-read"), notNullValue());
+    assertThat(histograms.get("fauna-request-reported-io-columns-written"), notNullValue());
+    assertThat(histograms.get("fauna-request-reported-io-counter-ops"), notNullValue());
+    assertThat(histograms.get("fauna-request-reported-io-countercolumns-written"), notNullValue());
+    assertThat(histograms.get("fauna-request-reported-io-insert-ops"), notNullValue());
+    assertThat(histograms.get("fauna-request-reported-io-read-ops"), notNullValue());
+    assertThat(histograms.get("fauna-request-reported-io-remove-ops"), notNullValue());
+    assertThat(histograms.get("fauna-request-reported-io-stack-size"), notNullValue());
+    assertThat(histograms.get("fauna-request-reported-io-transaction-count"), notNullValue());
+    assertThat(histograms.get("fauna-request-reported-locktable-attempts"), notNullValue());
+    assertThat(histograms.get("fauna-request-reported-locktable-successes"), notNullValue());
+    assertThat(histograms.get("fauna-request-reported-locktable-unlocks"), notNullValue());
+
+    SortedMap<String, Timer> timers = registry.getTimers();
+    assertThat(timers.get("fauna-request-reported-http-request-processing-time"), notNullValue());
+    assertThat(timers.get("fauna-request-reported-io-read-time"), notNullValue());
+    assertThat(timers.get("fauna-request-reported-io-write-time"), notNullValue());
+    assertThat(timers.get("fauna-request-reported-index-cached-getbysource"), notNullValue());
+  }
+}

--- a/faunadb-httpclient/src/test/resources/logback.xml
+++ b/faunadb-httpclient/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.ning.http.client.providers.netty.NettyAsyncHttpProvider" level="off"/>
+    <logger name="com.ning.http.client.providers.netty.NettyConnectionsPool" level="off"/>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -3,9 +3,10 @@ package com.faunadb.client;
 import com.faunadb.client.errors.BadRequestException;
 import com.faunadb.client.errors.NotFoundException;
 import com.faunadb.client.errors.UnauthorizedException;
-import com.faunadb.client.query.*;
+import com.faunadb.client.query.Path;
 import com.faunadb.client.response.*;
-import com.faunadb.client.types.*;
+import com.faunadb.client.types.Ref;
+import com.faunadb.client.types.Value;
 import com.faunadb.httpclient.Connection;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -18,21 +19,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static com.faunadb.client.query.Language.*;
+import static com.faunadb.client.query.Language.Object;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ClientSpec {
   @Rule

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9


### PR DESCRIPTION
I don't think this is a great way to handle stats, as we have to manually add each one.

I'd be happier if there were some standard for stat header names that clients can handle in some way. faunadb/core#2370 might be a good place to talk about that.

What do you guys think?