### PR TITLE
Macro lambda

### DIFF
--- a/faunadb-scala/src/main/scala/faunadb/query/Language.scala
+++ b/faunadb-scala/src/main/scala/faunadb/query/Language.scala
@@ -123,7 +123,7 @@ object Language {
   /**
    * A Lambda expression.
    *
-   * '''Reference''': TBD
+   * '''Reference''': [[https://faunadb.com/documentation/queries#basic_forms]]
    */
   def Lambda(fn: Value => Value): Value = macro LanguageMacros.lambda
   def Lambda(fn: (Value, Value) => Value): Value = macro LanguageMacros.lambda

--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -221,7 +221,7 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   }
 
   it should "test basic forms" in {
-    val letF = client.query(Let("x" -> 1L, "y" -> 2L)(Var("x")))
+    val letF = client.query(Let { val x = 1; val y = 2; x })
     val letR = Await.result(letF, 1 second)
     letR.asNumber shouldBe 1L
 

--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -246,11 +246,11 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   }
 
   it should "test collections" in {
-    val mapF = client.query(Map(Lambda("munchings" -> Add(Var("munchings"), 1L)), Arr(1L, 2L, 3L)))
+    val mapF = client.query(Map(Lambda(munchings => Add(munchings, 1L)), Arr(1L, 2L, 3L)))
     val mapR = Await.result(mapF, 1 second).asArray
     mapR.toSeq.map(_.asNumber) shouldBe Seq(2L, 3L, 4L)
 
-    val foreachF = client.query(Foreach(Lambda("spell" -> Create(Ref("classes/spells"), Obj("data" -> Obj("name" -> Var("spell"))))), ArrayV("Fireball Level 1", "Fireball Level 2")))
+    val foreachF = client.query(Foreach(Lambda(spell => Create(Ref("classes/spells"), Obj("data" -> Obj("name" -> spell)))), Arr("Fireball Level 1", "Fireball Level 2")))
     val foreachR = Await.result(foreachF, 1 second).asArray
     foreachR.toSeq.map(_.asString) shouldBe Seq("Fireball Level 1", "Fireball Level 2")
   }

--- a/faunadb-scala/src/test/scala/faunadb/SerializationSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/SerializationSpec.scala
@@ -36,8 +36,17 @@ class SerializationSpec extends FlatSpec with Matchers {
   }
 
   it should "serialize basic forms" in {
-    val let = Let("x" -> 1, "y" -> "2")(Var("x"))
+    val let = Let { val x = 1; val y = "2"; x }
     json.writeValueAsString(let) shouldBe "{\"let\":{\"x\":1,\"y\":\"2\"},\"in\":{\"var\":\"x\"}}"
+
+    val let2 = Let { val x = 1; val y = "2"; { val z = "foo"; x } }
+    json.writeValueAsString(let2) shouldBe "{\"let\":{\"x\":1,\"y\":\"2\"},\"in\":{\"var\":\"x\"}}"
+
+    val let3 = { val x0 = Var("x"); Let { val x = 1; val y = "2"; x0 } }
+    json.writeValueAsString(let3) shouldBe "{\"let\":{\"x\":1,\"y\":\"2\"},\"in\":{\"var\":\"x\"}}"
+
+    val let4 = Let(Seq("x" -> 1, "y" -> "2"), Var("x"))
+    json.writeValueAsString(let4) shouldBe "{\"let\":{\"x\":1,\"y\":\"2\"},\"in\":{\"var\":\"x\"}}"
 
     val ifForm = If(true, "was true", "was false")
     json.writeValueAsString(ifForm) shouldBe "{\"if\":true,\"then\":\"was true\",\"else\":\"was false\"}"

--- a/faunadb-scala/src/test/scala/faunadb/SerializationSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/SerializationSpec.scala
@@ -52,13 +52,16 @@ class SerializationSpec extends FlatSpec with Matchers {
   }
 
   it should "serialize collections" in {
-    val map = Map(Lambda("munchings" -> Var("munchings")), Arr(1, 2, 3))
+    val map = Map(Lambda(munchings => munchings), Arr(1, 2, 3))
     json.writeValueAsString(map) shouldBe "{\"map\":{\"lambda\":\"munchings\",\"expr\":{\"var\":\"munchings\"}},\"collection\":[1,2,3]}"
 
-    val foreach = Foreach(Lambda("creature" -> Create(Ref("some/ref"), Obj("data" -> Obj("some" -> Var("creature"))))), Arr(Ref("another/ref/1"), Ref("another/ref/2")))
+    val map2 = Map(Lambda("munchings", Var("munchings")), Arr(1, 2, 3))
+    json.writeValueAsString(map2) shouldBe "{\"map\":{\"lambda\":\"munchings\",\"expr\":{\"var\":\"munchings\"}},\"collection\":[1,2,3]}"
+
+    val foreach = Foreach(Lambda(creature => Create(Ref("some/ref"), Obj("data" -> Obj("some" -> creature)))), Arr(Ref("another/ref/1"), Ref("another/ref/2")))
     json.writeValueAsString(foreach) shouldBe "{\"foreach\":{\"lambda\":\"creature\",\"expr\":{\"create\":{\"@ref\":\"some/ref\"},\"params\":{\"object\":{\"data\":{\"object\":{\"some\":{\"var\":\"creature\"}}}}}}},\"collection\":[{\"@ref\":\"another/ref/1\"},{\"@ref\":\"another/ref/2\"}]}"
 
-    val filter = Filter(Lambda("i" -> Equals(1, Var("i"))), Arr(1,2,3))
+    val filter = Filter(Lambda(i => Equals(1, i)), Arr(1,2,3))
     json.writeValueAsString(filter) shouldBe "{\"filter\":{\"lambda\":\"i\",\"expr\":{\"equals\":[1,{\"var\":\"i\"}]}},\"collection\":[1,2,3]}"
 
     val take = Take(2, Arr(1,2,3))
@@ -142,7 +145,7 @@ class SerializationSpec extends FlatSpec with Matchers {
     val difference = Difference(Match(Ref("indexes/spells_by_element"), "fire"), Match(Ref("indexes/spells_by_element"), "water"))
     json.writeValueAsString(difference) shouldBe "{\"difference\":[{\"match\":\"fire\",\"index\":{\"@ref\":\"indexes/spells_by_element\"}},{\"match\":\"water\",\"index\":{\"@ref\":\"indexes/spells_by_element\"}}]}"
 
-    val join = Join(Match(Ref("indexes/spells_by_element"), "fire"), Lambda("spell" -> Get(Var("spell"))))
+    val join = Join(Match(Ref("indexes/spells_by_element"), "fire"), Lambda(spell => Get(spell)))
     json.writeValueAsString(join) shouldBe "{\"join\":{\"match\":\"fire\",\"index\":{\"@ref\":\"indexes/spells_by_element\"}},\"with\":{\"lambda\":\"spell\",\"expr\":{\"get\":{\"var\":\"spell\"}}}}"
   }
 


### PR DESCRIPTION
Shiny new syntax for Let and Lambda:

```scala
Let { val x = 1; val y = 2; Add(x, y) }
```

becomes

```json
{ "let": { "x": 1, "y": 2 }, "in": { "add": [{ "var": "x" }, { "var": "y" }] } }
```

and 

```scala
Lambda { (a, b, c) => [c, b, a] }
```

becomes

```json
{ "lambda": ["a", "b", "c"], "expr": [ { "var": "c" }, { "var": "b" }, { "var": "a" } ] }
```