### PR TITLE
Expr type to separate expressions from values.

### DIFF
--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -1,18 +1,17 @@
 package faunadb
 
-import java.io.IOException
-import java.net.ConnectException
-import java.util.concurrent.TimeoutException
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import faunadb.errors._
-import faunadb.types.{Value, LazyValue}
-import faunadb.util.FutureImplicits._
 import com.faunadb.httpclient.Connection
 import com.ning.http.client.{Response => HttpResponse}
-
+import faunadb.errors._
+import faunadb.query.Language
+import faunadb.types.{Value, LazyValue}
+import faunadb.util.FutureImplicits._
+import java.io.IOException
+import java.net.ConnectException
+import java.util.concurrent.TimeoutException
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -61,7 +60,7 @@ class FaunaClient private (connection: Connection, json: ObjectMapper) {
    * Responses are modeled as a general response tree. Each node is a [[faunadb.types.Value]],
    * and can be coerced into structured types through various methods on that class.
    */
-  def query(expr: Value)(implicit ec: ExecutionContext): Future[Value] = {
+  def query(expr: Language.Expr)(implicit ec: ExecutionContext): Future[Value] = {
     val body = json.createObjectNode()
     body.set("q", json.valueToTree(expr))
     connection.post("/", body).asScalaFuture.map { resp =>
@@ -79,7 +78,7 @@ class FaunaClient private (connection: Connection, json: ObjectMapper) {
    * The list of responses is returned in the same order as the issued queries.
    *
    */
-  def query(exprs: Iterable[Value])(implicit ec: ExecutionContext): Future[IndexedSeq[LazyValue]] = {
+  def query(exprs: Iterable[Language.Expr])(implicit ec: ExecutionContext): Future[IndexedSeq[LazyValue]] = {
     val body = json.createObjectNode()
     body.set("q", json.valueToTree(exprs))
     connection.post("/", body).asScalaFuture.map { resp =>

--- a/faunadb-scala/src/main/scala/faunadb/query/Language.scala
+++ b/faunadb-scala/src/main/scala/faunadb/query/Language.scala
@@ -1,9 +1,9 @@
 package faunadb.query
 
-import com.fasterxml.jackson.annotation._
+import com.fasterxml.jackson.annotation.JsonValue
 import faunadb.types._
 import language.experimental.macros
-import scala.annotation.meta.{field, getter}
+import scala.annotation.meta.getter
 import scala.reflect.macros._
 
 /**
@@ -17,53 +17,73 @@ import scala.reflect.macros._
  */
 object Language {
 
-  implicit def boolToValue(unwrapped: Boolean) = BooleanV(unwrapped)
-  implicit def stringToValue(unwrapped: String) = StringV(unwrapped)
-  implicit def intToValue(unwrapped: Int) = NumberV(unwrapped)
-  implicit def longToValue(unwrapped: Long) = NumberV(unwrapped)
-  implicit def floatToValue(unwrapped: Float) = DoubleV(unwrapped)
-  implicit def doubleToValue(unwrapped: Double) = DoubleV(unwrapped)
+  /**
+    * A query language expression.
+    */
+  case class Expr private[Language] (@(JsonValue @getter) value: Value) extends AnyVal
+
+  implicit def boolToExpr(unwrapped: Boolean) = Expr(BooleanV(unwrapped))
+  implicit def stringToExpr(unwrapped: String) = Expr(StringV(unwrapped))
+  implicit def intToExpr(unwrapped: Int) = Expr(NumberV(unwrapped))
+  implicit def longToExpr(unwrapped: Long) = Expr(NumberV(unwrapped))
+  implicit def floatToExpr(unwrapped: Float) = Expr(DoubleV(unwrapped))
+  implicit def doubleToExpr(unwrapped: Double) = Expr(DoubleV(unwrapped))
+  implicit def refToExpr(unwrapped: Ref) = Expr(unwrapped)
+  implicit def nullVToExpr(unwrapped: NullV.type) = Expr(unwrapped)
+
+  // FIXME: not sure if this is the best way to do this... would
+  // rather transform the value to a series of object constructions.
+  implicit def quotedValue(unwrapped: Value) = Expr(ObjectV("quote" -> unwrapped))
 
   /**
     * Enumeration for time units. Used by [[https://faunadb.com/documentation/queries#time_functions]].
     */
-  sealed abstract class TimeUnit(val value: String)
+  sealed abstract class TimeUnit(val expr: Expr)
   object TimeUnit {
-    case object Second extends TimeUnit("second")
-    case object Millisecond extends TimeUnit("millisecond")
-    case object Microsecond extends TimeUnit("microsecond")
-    case object Nanosecond extends TimeUnit("nanosecond")
+    case object Second extends TimeUnit(Expr(StringV("second")))
+    case object Millisecond extends TimeUnit(Expr(StringV("millisecond")))
+    case object Microsecond extends TimeUnit(Expr(StringV("microsecond")))
+    case object Nanosecond extends TimeUnit(Expr(StringV("nanosecond")))
   }
 
   /**
     * Enumeration for event action types.
     */
-  sealed abstract class Action(val value: String)
+  sealed abstract class Action(val expr: Expr)
   object Action {
-    case object Create extends Action("create")
-    case object Delete extends Action("delete")
+    case object Create extends Action(Expr(StringV("create")))
+    case object Delete extends Action(Expr(StringV("delete")))
   }
 
   /**
     * Helper for path syntax
     */
-  protected class Path(val segments: Value*) { def /(seg: Value) = new Path(segments :+ seg: _*) }
-  implicit def strToPath(str: String) = new Path(StringV(str))
-  implicit def intToPath(int: Int) = new Path(NumberV(int))
+  case class Path private (segments: Expr*) extends AnyVal {
+    def /(sub: Path) = Path(segments ++ sub.segments: _*)
+  }
+
+  implicit def strToPath(str: String) = Path(Expr(StringV(str)))
+  implicit def intToPath(int: Int) = Path(Expr(NumberV(int)))
 
   /**
     * Helper for pagination cursors
     */
   sealed trait Cursor
-  case class Before(value: Value) extends Cursor
-  case class After(value: Value) extends Cursor
+  case class Before(expr: Expr) extends Cursor
+  case class After(expr: Expr) extends Cursor
   case object NoCursor extends Cursor
 
-  private def varargs(exprs: Seq[Value]) =
+  private def varargs(exprs: Seq[Expr]) =
     exprs match {
-      case Seq(e) => e
-      case es     => ArrayV(es: _*)
+      case Seq(e) => e.value
+      case es     => ArrayV(es map (_.value): _*)
     }
+
+  private def unwrap(exprs: Seq[Expr]) =
+    exprs map { _.value }
+
+  private def unwrapPairs(exprs: Seq[(String, Expr)]) =
+    exprs map { t => (t._1, t._2.value) }
 
   // Values
 
@@ -72,16 +92,16 @@ object Language {
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#values]]
     */
-  def Arr(elems: Value*): Value =
-    ArrayV(elems: _*)
+  def Arr(elems: Expr*): Expr =
+    Expr(ArrayV(unwrap(elems): _*))
 
   /**
     * An Object value.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#values]]
     */
-  def Obj(pairs: (String, Value)*): Value =
-    ObjectV("object" -> ObjectV(pairs: _*))
+  def Obj(pairs: (String, Expr)*): Expr =
+    Expr(ObjectV("object" -> ObjectV(unwrapPairs(pairs): _*)))
 
   // Basic Forms
 
@@ -91,53 +111,53 @@ object Language {
     * '''Reference''': [[https://faunadb.com/documentation/queries#basic_forms]]
     */
 
-  def Let(block: => Any): Value = macro LanguageMacros.let
+  def Let(block: => Any): Expr = macro LanguageMacros.let
 
-  def Let(bindings: Seq[(String, Value)], in: Value): Value =
-    ObjectV("let" -> ObjectV(bindings: _*), "in" -> in)
+  def Let(bindings: Seq[(String, Expr)], in: Expr): Expr =
+    Expr(ObjectV("let" -> ObjectV(unwrapPairs(bindings): _*), "in" -> in.value))
 
   /**
     * A Var expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#basic_forms]]
     */
-  def Var(name: String): Value =
-    ObjectV("var" -> StringV(name))
+  def Var(name: String): Expr =
+    Expr(ObjectV("var" -> StringV(name)))
 
   /**
    * An If expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#basic_forms]]
    */
-  def If(condition: Value, `then`: Value, `else`: Value): Value =
-    ObjectV("if" -> condition, "then" -> `then`, "else" -> `else`)
+  def If(pred: Expr, `then`: Expr, `else`: Expr): Expr =
+    Expr(ObjectV("if" -> pred.value, "then" -> `then`.value, "else" -> `else`.value))
 
   /**
    * A Do expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#basic_forms]]
    */
-  def Do(exprs: Value*): Value =
-    ObjectV("do" -> varargs(exprs))
+  def Do(exprs: Expr*): Expr =
+    Expr(ObjectV("do" -> varargs(exprs)))
 
   /**
    * A Lambda expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#basic_forms]]
    */
-  def Lambda(fn: Value => Value): Value = macro LanguageMacros.lambda
-  def Lambda(fn: (Value, Value) => Value): Value = macro LanguageMacros.lambda
-  def Lambda(fn: (Value, Value, Value) => Value): Value = macro LanguageMacros.lambda
-  def Lambda(fn: (Value, Value, Value, Value) => Value): Value = macro LanguageMacros.lambda
-  def Lambda(fn: (Value, Value, Value, Value, Value) => Value): Value = macro LanguageMacros.lambda
-  def Lambda(fn: (Value, Value, Value, Value, Value, Value) => Value): Value = macro LanguageMacros.lambda
-  def Lambda(fn: (Value, Value, Value, Value, Value, Value, Value) => Value): Value = macro LanguageMacros.lambda
-  def Lambda(fn: (Value, Value, Value, Value, Value, Value, Value, Value) => Value): Value = macro LanguageMacros.lambda
-  def Lambda(fn: (Value, Value, Value, Value, Value, Value, Value, Value, Value) => Value): Value = macro LanguageMacros.lambda
-  def Lambda(fn: (Value, Value, Value, Value, Value, Value, Value, Value, Value, Value) => Value): Value = macro LanguageMacros.lambda
+  def Lambda(fn: Expr => Expr): Expr = macro LanguageMacros.lambda
+  def Lambda(fn: (Expr, Expr) => Expr): Expr = macro LanguageMacros.lambda
+  def Lambda(fn: (Expr, Expr, Expr) => Expr): Expr = macro LanguageMacros.lambda
+  def Lambda(fn: (Expr, Expr, Expr, Expr) => Expr): Expr = macro LanguageMacros.lambda
+  def Lambda(fn: (Expr, Expr, Expr, Expr, Expr) => Expr): Expr = macro LanguageMacros.lambda
+  def Lambda(fn: (Expr, Expr, Expr, Expr, Expr, Expr) => Expr): Expr = macro LanguageMacros.lambda
+  def Lambda(fn: (Expr, Expr, Expr, Expr, Expr, Expr, Expr) => Expr): Expr = macro LanguageMacros.lambda
+  def Lambda(fn: (Expr, Expr, Expr, Expr, Expr, Expr, Expr, Expr) => Expr): Expr = macro LanguageMacros.lambda
+  def Lambda(fn: (Expr, Expr, Expr, Expr, Expr, Expr, Expr, Expr, Expr) => Expr): Expr = macro LanguageMacros.lambda
+  def Lambda(fn: (Expr, Expr, Expr, Expr, Expr, Expr, Expr, Expr, Expr, Expr) => Expr): Expr = macro LanguageMacros.lambda
 
-  def Lambda(lambda: Value, expr: Value) =
-    ObjectV("lambda" -> lambda, "expr" -> expr)
+  def Lambda(lambda: Expr, expr: Expr) =
+    Expr(ObjectV("lambda" -> lambda.value, "expr" -> expr.value))
 
   class LanguageMacros(val c: whitebox.Context) {
     import c.universe._
@@ -158,7 +178,7 @@ object Language {
       }
 
       val varDefs = vals map { v => q"val ${v.name} = $M.Var(${v.name.toString})" }
-      val bindings = vals map { v => q"(${v.name.toString}, ${v.rhs}: $T.Value)" }
+      val bindings = vals map { v => q"(${v.name.toString}, ${v.rhs}: $M.Expr)" }
 
       val tv = q"$M.Let($bindings, { ..$varDefs; $expr })"
 
@@ -172,9 +192,9 @@ object Language {
       }
 
       val varDefs = vals map { v => q"val ${v.name} = $M.Var(${v.name.toString})" }
-      val paramsV = vals map { v => q"$T.StringV(${v.name.toString})" } match {
+      val paramsV = vals map { v => q"${v.name.toString}" } match {
         case List(p) => p
-        case ps => q"$T.ArrayV(..$ps)"
+        case ps => q"$M.Arr(..$ps)"
       }
 
       val tv = q"$M.Lambda($paramsV, { ..$varDefs; $expr })"
@@ -190,56 +210,56 @@ object Language {
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#collection_functions]]
    */
-  def Map(lambda: Value, collection: Value): Value =
-    ObjectV("map" -> lambda, "collection" -> collection)
+  def Map(lambda: Expr, collection: Expr): Expr =
+    Expr(ObjectV("map" -> lambda.value, "collection" -> collection.value))
 
   /**
    * A Foreach expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#collection_functions]]
    */
-  def Foreach(lambda: Value, collection: Value): Value =
-    ObjectV("foreach" -> lambda, "collection" -> collection)
+  def Foreach(lambda: Expr, collection: Expr): Expr =
+    Expr(ObjectV("foreach" -> lambda.value, "collection" -> collection.value))
 
   /**
     * A Filter expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#collection_functions]]
     */
-  def Filter(lambda: Value, collection: Value): Value =
-    ObjectV("filter" -> lambda, "collection" -> collection)
+  def Filter(lambda: Expr, collection: Expr): Expr =
+    Expr(ObjectV("filter" -> lambda.value, "collection" -> collection.value))
 
   /**
     * A Prepend expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#collection_functions]]
     */
-  def Prepend(elems: Value, collection: Value): Value =
-    ObjectV("prepend" -> elems, "collection" -> collection)
+  def Prepend(collection: Expr, elems: Expr): Expr =
+    Expr(ObjectV("prepend" -> elems.value, "collection" -> collection.value))
 
   /**
     * An Append expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#collection_functions]]
     */
-  def Append(elems: Value, collection: Value): Value =
-    ObjectV("append" -> elems, "collection" -> collection)
+  def Append(collection: Expr, elems: Expr): Expr =
+    Expr(ObjectV("append" -> elems.value, "collection" -> collection.value))
 
   /**
     * A Take expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#collection_functions]]
     */
-  def Take(num: Value, collection: Value): Value =
-    ObjectV("take" -> num, "collection" -> collection)
+  def Take(num: Expr, collection: Expr): Expr =
+    Expr(ObjectV("take" -> num.value, "collection" -> collection.value))
 
   /**
     * A Drop expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#collection_functions]]
     */
-  def Drop(num: Value, collection: Value): Value =
-    ObjectV("drop" -> num, "collection" -> collection)
+  def Drop(num: Expr, collection: Expr): Expr =
+    Expr(ObjectV("drop" -> num.value, "collection" -> collection.value))
 
   // Read Functions
 
@@ -248,11 +268,11 @@ object Language {
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#read_functions]]
    */
-  def Get(resource: Value): Value =
-    ObjectV("get" -> resource)
+  def Get(resource: Expr): Expr =
+    Expr(ObjectV("get" -> resource.value))
 
-  def Get(resource: Value, ts: Value): Value =
-    ObjectV("get" -> resource, "ts" -> ts)
+  def Get(resource: Expr, ts: Expr): Expr =
+    Expr(ObjectV("get" -> resource.value, "ts" -> ts.value))
 
   /**
    * A Paginate expression.
@@ -260,28 +280,30 @@ object Language {
    * '''Reference''': [[https://faunadb.com/documentation/queries#read_functions]]
    */
   def Paginate(
-    resource: Value,
+    resource: Expr,
     cursor: Cursor = NoCursor,
-    ts: Value = NullV,
-    size: Value = NullV,
-    sources: Value = NullV,
-    events: Value = NullV): Value = {
+    ts: Expr = Expr(NullV),
+    size: Expr = Expr(NullV),
+    sources: Expr = Expr(NullV),
+    events: Expr = Expr(NullV)): Expr = {
 
     val call = List.newBuilder[(String, Value)]
-    call += "paginate" -> resource
+    call += "paginate" -> resource.value
 
     cursor match {
-      case b: Before => call += "before" -> b.value
-      case a: After => call += "after" -> a.value
+      case b: Before => call += "before" -> b.expr.value
+      case a: After => call += "after" -> a.expr.value
       case _ => ()
     }
 
-    if (ts != NullV) call += "ts" -> ts
-    if (size != NullV) call += "size" -> size
-    if (events != NullV) call += "events" -> events
-    if (sources != NullV) call += "sources" -> sources
+    val nullExpr = Expr(NullV)
 
-    ObjectV(call.result: _*)
+    if (ts != nullExpr) call += "ts" -> ts.value
+    if (size != nullExpr) call += "size" -> size.value
+    if (events != nullExpr) call += "events" -> events.value
+    if (sources != nullExpr) call += "sources" -> sources.value
+
+    Expr(ObjectV(call.result: _*))
   }
 
   /**
@@ -289,19 +311,19 @@ object Language {
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#read_functions]]
    */
-  def Exists(ref: Value): Value =
-    ObjectV("exists" -> ref)
+  def Exists(ref: Expr): Expr =
+    Expr(ObjectV("exists" -> ref.value))
 
-  def Exists(ref: Value, ts: Value): Value =
-    ObjectV("exists" -> ref, "ts" -> ts)
+  def Exists(ref: Expr, ts: Expr): Expr =
+    Expr(ObjectV("exists" -> ref.value, "ts" -> ts.value))
 
   /**
    * A Count expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#read_functions]]
    */
-  def Count(set: Value): Value =
-    ObjectV("count" -> set)
+  def Count(set: Expr): Expr =
+    Expr(ObjectV("count" -> set.value))
 
   // Write Functions
 
@@ -310,54 +332,54 @@ object Language {
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#write_functions]]
    */
-  def Create(ref: Value, params: Value): Value =
-    ObjectV("create" -> ref, "params" -> params)
+  def Create(ref: Expr, params: Expr): Expr =
+    Expr(ObjectV("create" -> ref.value, "params" -> params.value))
 
   /**
    * An Update expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#write_functions]]
    */
-  def Update(ref: Value, params: Value): Value =
-    ObjectV("update" -> ref, "params" -> params)
+  def Update(ref: Expr, params: Expr): Expr =
+    Expr(ObjectV("update" -> ref.value, "params" -> params.value))
 
   /**
    * A Replace expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#write_functions]]
    */
-  def Replace(ref: Value, params: Value): Value =
-    ObjectV("replace" -> ref, "params" -> params)
+  def Replace(ref: Expr, params: Expr): Expr =
+    Expr(ObjectV("replace" -> ref.value, "params" -> params.value))
 
   /**
    * A Delete expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#write_functions]]
    */
-  def Delete(ref: Value): Value =
-    ObjectV("delete" -> ref)
+  def Delete(ref: Expr): Expr =
+    Expr(ObjectV("delete" -> ref.value))
 
   /**
     * An Insert expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#write_functions]]
     */
-  def Insert(ref: Value, ts: Long, action: Action, params: Value): Value =
-    Insert(ref, ts, action.value, params)
+  def Insert(ref: Expr, ts: Expr, action: Action, params: Expr): Expr =
+    Insert(ref, ts, action.expr, params)
 
-  def Insert(ref: Value, ts: Long, action: Value, params: Value): Value =
-    ObjectV("insert" -> ref, "ts" -> ts, "action" -> action, "params" -> params)
+  def Insert(ref: Expr, ts: Expr, action: Expr, params: Expr): Expr =
+    Expr(ObjectV("insert" -> ref.value, "ts" -> ts.value, "action" -> action.value, "params" -> params.value))
 
   /**
     * A Remove expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#write_functions]]
     */
-  def Remove(ref: Value, ts: Long, action: Action): Value =
-    Remove(ref, ts, action.value)
+  def Remove(ref: Expr, ts: Expr, action: Action): Expr =
+    Remove(ref, ts, action.expr)
 
-  def Remove(ref: Value, ts: Long, action: Value): Value =
-    ObjectV("remove" -> ref, "ts" -> ts, "action" -> action)
+  def Remove(ref: Expr, ts: Expr, action: Expr): Expr =
+    Expr(ObjectV("remove" -> ref.value, "ts" -> ts.value, "action" -> action.value))
 
   // Set Constructors
 
@@ -366,48 +388,48 @@ object Language {
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#sets]]
    */
-  def Match(index: Value, terms: Value*) =
-    ObjectV("match" -> varargs(terms), "index" -> index)
+  def Match(index: Expr, terms: Expr*): Expr =
+    Expr(ObjectV("match" -> varargs(terms), "index" -> index.value))
 
   /**
    * A Union set.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#sets]]
    */
-  def Union(sets: Value*): Value =
-    ObjectV("union" -> varargs(sets))
+  def Union(sets: Expr*): Expr =
+    Expr(ObjectV("union" -> varargs(sets)))
 
   /**
    * An Intersection set.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#sets]]
    */
-  def Intersection(sets: Value*): Value =
-    ObjectV("intersection" -> varargs(sets))
+  def Intersection(sets: Expr*): Expr =
+    Expr(ObjectV("intersection" -> varargs(sets)))
 
   /**
    * A Difference set.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#sets]]
    */
-  def Difference(sets: Value*): Value =
-    ObjectV("difference" -> varargs(sets))
+  def Difference(sets: Expr*): Expr =
+    Expr(ObjectV("difference" -> varargs(sets)))
 
   /**
    * A Distinct set.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#sets]]
    */
-  def Distinct(set: Value): Value =
-    ObjectV("distinct" -> set)
+  def Distinct(set: Expr): Expr =
+    Expr(ObjectV("distinct" -> set.value))
 
   /**
    * A Join set.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#sets]]
    */
-  def Join(source: Value, `with`: Value): Value =
-    ObjectV("join" -> source, "with" -> `with`)
+  def Join(source: Expr, `with`: Expr): Expr =
+    Expr(ObjectV("join" -> source.value, "with" -> `with`.value))
 
   // Authentication Functions
 
@@ -416,24 +438,24 @@ object Language {
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#auth_functions]]
     */
-  def Login(ref: Value, params: Value): Value =
-    ObjectV("login" -> ref, "params" -> params)
+  def Login(ref: Expr, params: Expr): Expr =
+    Expr(ObjectV("login" -> ref.value, "params" -> params.value))
 
   /**
     * A Logout expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#auth_functions]]
     */
-  def Logout(invalidateAll: Value): Value =
-    ObjectV("logout" -> invalidateAll)
+  def Logout(invalidateAll: Expr): Expr =
+    Expr(ObjectV("logout" -> invalidateAll.value))
 
   /**
     * An Identify expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#auth_functions]]
     */
-  def Identify(ref: Value, password: Value): Value =
-    ObjectV("identify" -> ref, "password" -> password)
+  def Identify(ref: Expr, password: Expr): Expr =
+    Expr(ObjectV("identify" -> ref.value, "password" -> password.value))
 
   // String Functions
 
@@ -442,19 +464,19 @@ object Language {
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#string_functions]]
    */
-  def Concat(term: Value): Value =
-    ObjectV("concat" -> term)
+  def Concat(term: Expr): Expr =
+    Expr(ObjectV("concat" -> term.value))
 
-  def Concat(term: Value, separator: Value): Value =
-    ObjectV("concat" -> term, "separator" -> separator)
+  def Concat(term: Expr, separator: Expr): Expr =
+    Expr(ObjectV("concat" -> term.value, "separator" -> separator.value))
 
   /**
    * A Casefold expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#string_functions]]
    */
-  def Casefold(term: Value): Value =
-    ObjectV("casefold" -> term)
+  def Casefold(term: Expr): Expr =
+    Expr(ObjectV("casefold" -> term.value))
 
   // Time Functions
 
@@ -463,27 +485,27 @@ object Language {
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#time_functions]]
     */
-  def Time(str: Value): Value =
-    ObjectV("time" -> str)
+  def Time(str: Expr): Expr =
+    Expr(ObjectV("time" -> str.value))
 
   /**
     * An Epoch expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#time_functions]]
     */
-  def Epoch(num: Value, unit: TimeUnit): Value =
-    Epoch(num, unit.value)
+  def Epoch(num: Expr, unit: TimeUnit): Expr =
+    Epoch(num, unit.expr)
 
-  def Epoch(num: Value, unit: Value): Value =
-    ObjectV("epoch" -> num, "unit" -> unit)
+  def Epoch(num: Expr, unit: Expr): Expr =
+    Expr(ObjectV("epoch" -> num.value, "unit" -> unit.value))
 
   /**
     * A Date expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#time_functions]]
     */
-  def Date(str: Value): Value =
-    ObjectV("date" -> str)
+  def Date(str: Expr): Expr =
+    Expr(ObjectV("date" -> str.value))
 
   // Misc Functions
 
@@ -492,130 +514,130 @@ object Language {
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
    */
-  def Equals(terms: Value*): Value =
-    ObjectV("equals" -> varargs(terms))
+  def Equals(terms: Expr*): Expr =
+    Expr(ObjectV("equals" -> varargs(terms)))
 
   /**
    * A Contains expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
    */
-  def Contains(path: Path, in: Value): Value =
-    Contains(varargs(path.segments), in)
+  def Contains(path: Path, in: Expr): Expr =
+    Expr(ObjectV("contains" -> varargs(path.segments), "in" -> in.value))
 
-  def Contains(path: Value, in: Value): Value =
-    ObjectV("contains" -> path, "in" -> in)
+  def Contains(path: Expr, in: Expr): Expr =
+    Expr(ObjectV("contains" -> path.value, "in" -> in.value))
 
   /**
    * A Select expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
    */
-  def Select(path: Path, from: Value): Value =
-    Select(varargs(path.segments), from)
+  def Select(path: Path, from: Expr): Expr =
+    Expr(ObjectV("select" -> varargs(path.segments), "from" -> from.value))
 
-  def Select(path: Path, from: Value, default: Value): Value =
-    Select(varargs(path.segments), from, default)
+  def Select(path: Path, from: Expr, default: Expr): Expr =
+    Expr(ObjectV("select" -> varargs(path.segments), "from" -> from.value, "default" -> default.value))
 
-  def Select(path: Value, from: Value): Value =
-    ObjectV("select" -> path, "from" -> from)
+  def Select(path: Expr, from: Expr): Expr =
+    Expr(ObjectV("select" -> path.value, "from" -> from.value))
 
-  def Select(path: Value, from: Value, default: Value): Value =
-    ObjectV("select" -> path, "from" -> from, "default" -> default)
+  def Select(path: Expr, from: Expr, default: Expr): Expr =
+    Expr(ObjectV("select" -> path.value, "from" -> from.value, "default" -> default.value))
 
   /**
    * An Add expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
    */
-  def Add(terms: Value*): Value =
-    ObjectV("add" -> varargs(terms))
+  def Add(terms: Expr*): Expr =
+    Expr(ObjectV("add" -> varargs(terms)))
 
   /**
    * A Multiply expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
    */
-  def Multiply(terms: Value*): Value =
-    ObjectV("multiply" -> varargs(terms))
+  def Multiply(terms: Expr*): Expr =
+    Expr(ObjectV("multiply" -> varargs(terms)))
 
   /**
    * A Subtract expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
    */
-  def Subtract(terms: Value*): Value =
-    ObjectV("subtract" -> varargs(terms))
+  def Subtract(terms: Expr*): Expr =
+    Expr(ObjectV("subtract" -> varargs(terms)))
 
   /**
    * A Divide expression.
    *
    * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
    */
-  def Divide(terms: Value*): Value =
-    ObjectV("divide" -> varargs(terms))
+  def Divide(terms: Expr*): Expr =
+    Expr(ObjectV("divide" -> varargs(terms)))
 
   /**
     * A Modulo expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
     */
-  def Modulo(terms: Value*): Value =
-    ObjectV("modulo" -> varargs(terms))
+  def Modulo(terms: Expr*): Expr =
+    Expr(ObjectV("modulo" -> varargs(terms)))
 
   /**
     * A LT expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
     */
-  def LT(terms: Value*): Value =
-    ObjectV("lt" -> varargs(terms))
+  def LT(terms: Expr*): Expr =
+    Expr(ObjectV("lt" -> varargs(terms)))
 
   /**
     * A LTE expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
     */
-  def LTE(terms: Value*): Value =
-    ObjectV("lte" -> varargs(terms))
+  def LTE(terms: Expr*): Expr =
+    Expr(ObjectV("lte" -> varargs(terms)))
 
   /**
     * A GT expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
     */
-  def GT(terms: Value*): Value =
-    ObjectV("gt" -> varargs(terms))
+  def GT(terms: Expr*): Expr =
+    Expr(ObjectV("gt" -> varargs(terms)))
 
   /**
     * A GTE expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
     */
-  def GTE(terms: Value*): Value =
-    ObjectV("gte" -> varargs(terms))
+  def GTE(terms: Expr*): Expr =
+    Expr(ObjectV("gte" -> varargs(terms)))
 
   /**
     * An And expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
     */
-  def And(terms: Value*): Value =
-    ObjectV("and" -> varargs(terms))
+  def And(terms: Expr*): Expr =
+    Expr(ObjectV("and" -> varargs(terms)))
 
   /**
     * An Or expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
     */
-  def Or(terms: Value*): Value =
-    ObjectV("or" -> varargs(terms))
+  def Or(terms: Expr*): Expr =
+    Expr(ObjectV("or" -> varargs(terms)))
 
   /**
     * A Not expression.
     *
     * '''Reference''': [[https://faunadb.com/documentation/queries#misc_functions]]
     */
-  def Not(term: Value): Value =
-    ObjectV("not" -> term)
+  def Not(term: Expr): Expr =
+    Expr(ObjectV("not" -> term.value))
 }

--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -70,6 +70,11 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     }
   }
 
+  it should "echo values" in {
+    val resp = client.query(ObjectV("foo" -> StringV("bar")))
+    Await.result(resp, 1 second)("foo").asString should equal ("bar")
+  }
+
   it should "fail with unauthorized" in {
     val badClient = FaunaClient(Connection.builder().withFaunaRoot(config("root_url")).withAuthToken("notavalidsecret").build())
     val resp = badClient.query(Get(Ref("classes/spells/12345")))
@@ -270,7 +275,7 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     updateR.data("element").asString shouldBe "arcane"
     updateR.data.get("cost") shouldBe None
 
-    val replaceF = client.query(Replace(createR.ref, Obj("data" -> Obj("name" -> "Volcano", "element" -> ArrayV("fire", "earth"), "cost" -> 10L))))
+    val replaceF = client.query(Replace(createR.ref, Obj("data" -> Obj("name" -> "Volcano", "element" -> Arr("fire", "earth"), "cost" -> 10L))))
     val replaceR = Await.result(replaceF, 1 second).asInstance
     replaceR.ref shouldBe createR.ref
     replaceR.data("name").asString shouldBe "Volcano"
@@ -357,11 +362,11 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     val concat2R = Await.result(concat2F, 1 second).asString
     concat2R shouldBe "Magic Missile"
 
-    val containsF = client.query(Contains("favorites" / "foods", Obj("favorites" -> Obj("foods" -> ArrayV("crunchings", "munchings")))))
+    val containsF = client.query(Contains("favorites" / "foods", Obj("favorites" -> Obj("foods" -> Arr("crunchings", "munchings")))))
     val containsR = Await.result(containsF, 1 second).asBoolean
     containsR shouldBe true
 
-    val selectF = client.query(Select("favorites" / "foods" / 1, Obj("favorites" -> Obj("foods" -> ArrayV("crunchings", "munchings", "lunchings")))))
+    val selectF = client.query(Select("favorites" / "foods" / 1, Obj("favorites" -> Obj("foods" -> Arr("crunchings", "munchings", "lunchings")))))
     val selectR = Await.result(selectF, 1 second).asString
     selectR shouldBe "munchings"
 

--- a/faunadb-scala/src/test/scala/faunadb/SerializationSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/SerializationSpec.scala
@@ -79,10 +79,10 @@ class SerializationSpec extends FlatSpec with Matchers {
     val drop = Drop(2, Arr(1,2,3))
     json.writeValueAsString(drop) shouldBe "{\"drop\":2,\"collection\":[1,2,3]}"
 
-    val prepend = Prepend(Arr(1,2,3), Arr(4,5,6))
+    val prepend = Prepend(Arr(4,5,6), Arr(1,2,3))
     json.writeValueAsString(prepend) shouldBe "{\"prepend\":[1,2,3],\"collection\":[4,5,6]}"
 
-    val append = Append(Arr(4,5,6), Arr(1,2,3))
+    val append = Append(Arr(1,2,3), Arr(4,5,6))
     json.writeValueAsString(append) shouldBe "{\"append\":[4,5,6],\"collection\":[1,2,3]}"
   }
 


### PR DESCRIPTION
removes the need for "quote", as expressions and values are differentiated at the type level, and we can convert values in a way to avoid the need for manual quoting.