### PR TITLE
Adjusting idle timeout for JVM drivers

### DIFF
--- a/faunadb-httpclient/src/main/java/com/faunadb/httpclient/Connection.java
+++ b/faunadb-httpclient/src/main/java/com/faunadb/httpclient/Connection.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -31,6 +30,7 @@ import java.util.Map;
 public class Connection {
   static final int DEFAULT_CONNECTION_TIMEOUT_MS = 10000;
   static final int DEFAULT_REQUEST_TIMEOUT_MS = 60000;
+  static final int DEFAULT_IDLE_TIMEOUT_MS = 4750;
 
   /**
    * Returns a new {@link Connection.Builder}.
@@ -128,6 +128,7 @@ public class Connection {
         AsyncHttpClientConfig config = new AsyncHttpClientConfig.Builder()
           .setConnectTimeout(DEFAULT_CONNECTION_TIMEOUT_MS)
           .setRequestTimeout(DEFAULT_REQUEST_TIMEOUT_MS)
+          .setPooledConnectionIdleTimeout(DEFAULT_IDLE_TIMEOUT_MS)
           .setMaxRequestRetry(0)
           .build();
         c = new AsyncHttpClient(config);


### PR DESCRIPTION
The default was 60000, which is bigger than the server: 5000.
I've set to 4750 so we are sure that the client recycles the connection before the server closes it.