### PR TITLE
Making JavaClient implements AutoCloseable interface

### DIFF
--- a/faunadb-common/src/main/java/com/faunadb/common/Connection.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/Connection.java
@@ -255,12 +255,8 @@ public class Connection {
    * Releases any resources being held by the HTTP client. Also closes the underlying
    * {@link AsyncHttpClient}.
    */
-  public void close() {
-    try {
-      client.close();
-    } catch (IOException e) {
-      // Ignore. Probably already closed.
-    }
+  public void close() throws IOException {
+    client.close();
   }
 
   private ListenableFuture<Response> performRequest(final Request request) throws IOException {

--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeoutException;
  *
  * @see com.faunadb.client.query.Language
  */
-public class FaunaClient {
+public class FaunaClient implements AutoCloseable {
 
   private static final Charset UTF8 = Charset.forName("UTF-8");
 
@@ -73,7 +73,8 @@ public class FaunaClient {
   /**
    * Frees any resources held by the client. Also closes the underlying {@link Connection}.
    */
-  public void close() {
+  @Override
+  public void close() throws IOException {
     connection.close();
   }
 

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -801,13 +801,11 @@ public class ClientSpec extends FaunaDBTest {
         Obj("password", Value("abcdefg")))
     ).get();
 
-    FaunaClient sessionClient = createFaunaClient(auth.at("secret").to(STRING).get());
+    String secret = auth.at("secret").to(STRING).get();
 
-    try {
+    try (FaunaClient sessionClient = createFaunaClient(secret)) {
       Value loggedOut = sessionClient.query(Logout(Value(true))).get();
       assertThat(loggedOut.to(BOOLEAN).get(), is(true));
-    } finally {
-      sessionClient.close();
     }
 
     Value identified = client.query(


### PR DESCRIPTION
It helps when creating short live connections with instances' tokens.