### PR TITLE
Improving driver initialisation

### DIFF
--- a/faunadb-common/src/main/java/com/faunadb/common/Connection.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/Connection.java
@@ -13,6 +13,7 @@ import org.asynchttpclient.util.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOError;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
@@ -43,7 +44,7 @@ public final class Connection implements AutoCloseable {
     try {
       FAUNA_ROOT = new URL("https://rest.faunadb.com");
     } catch (MalformedURLException e) {
-      throw new RuntimeException(e); // won't happen
+      throw new IOError(e); // won't happen
     }
   }
 

--- a/faunadb-common/src/main/java/com/faunadb/common/Connection.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/Connection.java
@@ -180,6 +180,13 @@ public final class Connection {
     this.refCount = refCount;
   }
 
+  /**
+   * Creates a new short live connection sharing its underneath {@link AsyncHttpClient}. Queries submited to a
+   * session connection will be authenticated with the token provided.
+   *
+   * @param authToken token that will be used to authenticate requests
+   * @return a new {@link Connection}
+   */
   public Connection newSessionConnection(String authToken) {
     if (refCount.incrementAndGet() > 1)
       return new Connection(faunaRoot, authToken, client, registry, refCount);

--- a/faunadb-common/src/main/java/com/faunadb/common/Connection.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/Connection.java
@@ -30,7 +30,7 @@ import static java.lang.String.format;
  * for the underlying implementation.
  */
 
-public class Connection {
+public final class Connection {
 
   private static final int DEFAULT_CONNECTION_TIMEOUT_MS = 10000;
   private static final int DEFAULT_REQUEST_TIMEOUT_MS = 60000;

--- a/faunadb-common/src/main/java/com/faunadb/common/Connection.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/Connection.java
@@ -20,6 +20,8 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
+import static java.lang.String.format;
+
 /**
  * The HTTP Connection adapter for FaunaDB clients.
  * <p>
@@ -28,9 +30,20 @@ import java.util.Map;
  */
 
 public class Connection {
-  static final int DEFAULT_CONNECTION_TIMEOUT_MS = 10000;
-  static final int DEFAULT_REQUEST_TIMEOUT_MS = 60000;
-  static final int DEFAULT_IDLE_TIMEOUT_MS = 4750;
+
+  private static final int DEFAULT_CONNECTION_TIMEOUT_MS = 10000;
+  private static final int DEFAULT_REQUEST_TIMEOUT_MS = 60000;
+  private static final int DEFAULT_IDLE_TIMEOUT_MS = 4750;
+  private static final int DEFAULT_MAX_RETRIES = 0;
+  private static final URL FAUNA_ROOT;
+
+  static {
+    try {
+      FAUNA_ROOT = new URL("https://rest.faunadb.com");
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e); // won't happen
+    }
+  }
 
   /**
    * Returns a new {@link Connection.Builder}.
@@ -44,6 +57,7 @@ public class Connection {
    * an instance of this builder.
    */
   public static class Builder {
+
     private URL faunaRoot;
     private String authToken;
     private AsyncHttpClient client;
@@ -112,44 +126,43 @@ public class Connection {
 
     /**
      * Returns a newly constructed {@link Connection} with configuration based on the settings of this {@link Builder}.
-     *
-     * @throws UnsupportedEncodingException if the system does not support ASCII encoding for the Connection.
-     * @throws MalformedURLException        if the default FaunaDB URL cannot be parsed.
      */
-    public Connection build() throws UnsupportedEncodingException, MalformedURLException {
-      MetricRegistry r;
+    public Connection build() {
+      MetricRegistry registry;
       if (metricRegistry == null)
-        r = new MetricRegistry();
+        registry = new MetricRegistry();
       else
-        r = metricRegistry;
+        registry = metricRegistry;
 
-      AsyncHttpClient c;
+      AsyncHttpClient httpClient;
       if (client == null) {
-        AsyncHttpClientConfig config = new DefaultAsyncHttpClientConfig.Builder()
-          .setConnectTimeout(DEFAULT_CONNECTION_TIMEOUT_MS)
-          .setRequestTimeout(DEFAULT_REQUEST_TIMEOUT_MS)
-          .setPooledConnectionIdleTimeout(DEFAULT_IDLE_TIMEOUT_MS)
-          .setMaxRequestRetry(0)
-          .build();
-        c = new DefaultAsyncHttpClient(config);
-      } else
-        c = client;
+        httpClient = new DefaultAsyncHttpClient(
+          new DefaultAsyncHttpClientConfig.Builder()
+            .setConnectTimeout(DEFAULT_CONNECTION_TIMEOUT_MS)
+            .setRequestTimeout(DEFAULT_REQUEST_TIMEOUT_MS)
+            .setPooledConnectionIdleTimeout(DEFAULT_IDLE_TIMEOUT_MS)
+            .setMaxRequestRetry(DEFAULT_MAX_RETRIES)
+            .build()
+        );
+      } else {
+        httpClient = client;
+      }
 
       URL root;
       if (faunaRoot == null)
-        root = new URL("https://rest.faunadb.com");
+        root = FAUNA_ROOT;
       else
         root = faunaRoot;
 
-      return new Connection(root, authToken, c, r);
+      return new Connection(root, authToken, httpClient, registry);
     }
   }
 
-  private static String XFaunaDBHost = "X-FaunaDB-Host";
-  private static String XFaunaDBBuild = "X-FaunaDB-Build";
+  private static final String ASCII = "ASCII";
+  private static final String X_FAUNADB_HOST = "X-FaunaDB-Host";
+  private static final String X_FAUNADB_BUILD = "X-FaunaDB-Build";
 
   private final URL faunaRoot;
-  private final String authToken;
   private final String authHeader;
   private final AsyncHttpClient client;
   private final MetricRegistry registry;
@@ -157,9 +170,8 @@ public class Connection {
   private final Logger log = LoggerFactory.getLogger(getClass());
   private final ObjectMapper json = new ObjectMapper();
 
-  Connection(URL faunaRoot, String authToken, AsyncHttpClient client, MetricRegistry registry) throws UnsupportedEncodingException {
+  private Connection(URL faunaRoot, String authToken, AsyncHttpClient client, MetricRegistry registry) {
     this.faunaRoot = faunaRoot;
-    this.authToken = authToken;
     this.authHeader = generateAuthHeader(authToken);
     this.client = client;
     this.registry = registry;
@@ -259,7 +271,7 @@ public class Connection {
     client.close();
   }
 
-  private ListenableFuture<Response> performRequest(final Request request) throws IOException {
+  private ListenableFuture<Response> performRequest(final Request request) {
     final Timer.Context ctx = registry.timer("fauna-request").time();
     final SettableFuture<Response> rv = SettableFuture.create();
 
@@ -289,24 +301,33 @@ public class Connection {
     return new URL(faunaRoot, path).toString();
   }
 
-  private void logSuccess(Request request, Response response) throws IOException {
-    String requestData = Optional.fromNullable(request.getStringData()).or("");
-    String faunaHost = Optional.fromNullable(response.getHeader(XFaunaDBHost)).or("Unknown");
-    String faunaBuild = Optional.fromNullable(response.getHeader(XFaunaDBBuild)).or("Unknown");
-    String responseBody = Optional.fromNullable(response.getResponseBody()).or("");
+  private void logSuccess(Request request, Response response) {
+    if (log.isDebugEnabled()) {
+      String data = Optional.fromNullable(request.getStringData()).or("");
+      String host = Optional.fromNullable(response.getHeader(X_FAUNADB_HOST)).or("Unknown");
+      String build = Optional.fromNullable(response.getHeader(X_FAUNADB_BUILD)).or("Unknown");
+      String body = Optional.fromNullable(response.getResponseBody()).or("");
 
-    log.debug("Request: " + request.getMethod() + " " + request.getUrl() + ": " + requestData + ". " +
-      "Response: Status=" + response.getStatusCode() + ", Fauna Host: " + faunaHost + ", " +
-      "Fauna Build: " + faunaBuild + ": " + responseBody);
+      log.debug(
+        format("Request: %s %s: %s. Response: Status=%d, Fauna Host: %s, Fauna Build: %s: %s",
+          request.getMethod(), request.getUrl(), data, response.getStatusCode(), host, build, body));
+    }
   }
 
   private void logFailure(Request request, Throwable ex) {
-    String requestData = Optional.fromNullable(request.getStringData()).or("");
-    log.info("Request: " + request.getMethod() + " " + request.getUrl() + ": " + requestData + ". " +
-      "Failed: " + ex.getMessage(), ex);
+    String data = Optional.fromNullable(request.getStringData()).or("");
+
+    log.info(
+      format("Request: %s %s: %s. Failed: %s",
+        request.getMethod(), request.getUrl(), data, ex.getMessage()), ex);
   }
 
-  private static String generateAuthHeader(String authToken) throws UnsupportedEncodingException {
-    return "Basic " + Base64.encode((authToken + ":").getBytes("ASCII"));
+  private static String generateAuthHeader(String authToken) {
+    try {
+      String token = authToken + ":";
+      return "Basic " + Base64.encode(token.getBytes(ASCII));
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException(e); // If ASCII is not supported there is no recovery action to be taken
+    }
   }
 }

--- a/faunadb-common/src/main/java/com/faunadb/common/RefAwareHttpClient.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/RefAwareHttpClient.java
@@ -1,0 +1,42 @@
+package com.faunadb.common;
+
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.Request;
+
+import java.io.IOError;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class RefAwareHttpClient implements AutoCloseable {
+
+  private static final int INITIAL_REF_COUNT = 1;
+
+  private final AtomicInteger refCount = new AtomicInteger(INITIAL_REF_COUNT);
+  private final AsyncHttpClient delegate;
+
+  RefAwareHttpClient(AsyncHttpClient delegate) {
+    this.delegate = delegate;
+  }
+
+  boolean retain() {
+    return refCount.incrementAndGet() > INITIAL_REF_COUNT && !delegate.isClosed();
+  }
+
+  @Override
+  public void close() {
+    try {
+      if (refCount.decrementAndGet() < INITIAL_REF_COUNT && !delegate.isClosed()) {
+        delegate.close();
+      }
+    } catch (IOException e) {
+      // DefaultAsyncHttpClient do not throw IOException, we don't need to pollute the API with it
+      throw new IOError(e);
+    }
+  }
+
+  BoundRequestBuilder prepareRequest(Request request) {
+    return delegate.prepareRequest(request);
+  }
+
+}

--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -98,6 +98,10 @@ public class FaunaClient implements AutoCloseable {
     this.connection = connection;
   }
 
+  public FaunaClient newSessionClient(String secret) {
+    return new FaunaClient(connection.newSessionConnection(secret));
+  }
+
   /**
    * Frees any resources held by the client. Also closes the underlying {@link Connection}.
    */

--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -17,9 +17,9 @@ import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.Response;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.ConnectException;
 import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
@@ -45,10 +45,14 @@ public class FaunaClient implements AutoCloseable {
 
   private static final Charset UTF8 = Charset.forName("UTF-8");
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   public static final class Builder {
 
     private String secret;
-    private String endpoint;
+    private URL endpoint;
     private MetricRegistry metrics;
     private AsyncHttpClient httpClient;
 
@@ -60,8 +64,8 @@ public class FaunaClient implements AutoCloseable {
       return this;
     }
 
-    public Builder withEndpoint(String endpoint) {
-      this.endpoint = endpoint;
+    public Builder withEndpoint(String endpoint) throws MalformedURLException {
+      this.endpoint = new URL(endpoint);
       return this;
     }
 
@@ -75,7 +79,7 @@ public class FaunaClient implements AutoCloseable {
       return this;
     }
 
-    public FaunaClient build() throws MalformedURLException, UnsupportedEncodingException {
+    public FaunaClient build() {
       Connection.Builder builder = Connection.builder()
         .withAuthToken(secret)
         .withFaunaRoot(endpoint);
@@ -85,10 +89,6 @@ public class FaunaClient implements AutoCloseable {
 
       return new FaunaClient(builder.build());
     }
-  }
-
-  public static Builder builder() {
-    return new Builder();
   }
 
   private final ObjectMapper json = new ObjectMapper().registerModule(new GuavaModule());

--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -45,10 +45,16 @@ public class FaunaClient implements AutoCloseable {
 
   private static final Charset UTF8 = Charset.forName("UTF-8");
 
+  /**
+   * Creates a new {@link Builder}
+   */
   public static Builder builder() {
     return new Builder();
   }
 
+  /**
+   * A builder for creating an instance of {@link FaunaClient}
+   */
   public static final class Builder {
 
     private String secret;
@@ -59,26 +65,55 @@ public class FaunaClient implements AutoCloseable {
     private Builder() {
     }
 
+    /**
+     * Sets the secret to be passed to FaunaDB as a authentication token
+     *
+     * @param secret the auth token secret
+     * @return this {@link Builder} object
+     */
     public Builder withSecret(String secret) {
       this.secret = secret;
       return this;
     }
 
+    /**
+     * Sets the FaunaDB endpoint url for the built {@link FaunaClient}.
+     *
+     * @param endpoint the root endpoint URL
+     * @return this {@link Builder} object
+     */
     public Builder withEndpoint(String endpoint) throws MalformedURLException {
       this.endpoint = new URL(endpoint);
       return this;
     }
 
-    public Builder withMetrics(MetricRegistry metrics) {
-      this.metrics = metrics;
+    /**
+     * Sets a {@link MetricRegistry} that the {@link FaunaClient} will use to register and track Connection-level
+     * statistics.
+     *
+     * @param registry the MetricRegistry instance.
+     * @return this {@link Builder} object
+     */
+    public Builder withMetrics(MetricRegistry registry) {
+      this.registry = registry;
       return this;
     }
 
+    /**
+     * Sets a custom {@link AsyncHttpClient} implementation that the built {@link FaunaClient} will use.
+     * This custom implementation can be provided to control the behavior of the underlying HTTP transport.
+     *
+     * @param httpClient the custom {@link AsyncHttpClient} instance
+     * @return this {@link Builder} object
+     */
     public Builder withHttpClient(AsyncHttpClient httpClient) {
       this.httpClient = httpClient;
       return this;
     }
 
+    /**
+     * Returns a newly constructed {@link FaunaClient} with configuration based on the settings of this {@link Builder}.
+     */
     public FaunaClient build() {
       Connection.Builder builder = Connection.builder()
         .withAuthToken(secret)
@@ -98,6 +133,13 @@ public class FaunaClient implements AutoCloseable {
     this.connection = connection;
   }
 
+  /**
+   * Creates a session client with the user secret provided. Queries submited to a session client will be
+   * authenticated with the secret provided. A Session client shares its parent's {@link Connection} instance.
+   *
+   * @param secret user secret for the session client
+   * @return a new {@link FaunaClient}
+   */
   public FaunaClient newSessionClient(String secret) {
     return new FaunaClient(connection.newSessionConnection(secret));
   }

--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -53,7 +53,7 @@ public class FaunaClient implements AutoCloseable {
 
     private String secret;
     private URL endpoint;
-    private MetricRegistry metrics;
+    private MetricRegistry registry;
     private AsyncHttpClient httpClient;
 
     private Builder() {
@@ -84,7 +84,7 @@ public class FaunaClient implements AutoCloseable {
         .withAuthToken(secret)
         .withFaunaRoot(endpoint);
 
-      if (metrics != null) builder.withMetrics(metrics);
+      if (registry != null) builder.withMetrics(registry);
       if (httpClient != null) builder.withHttpClient(httpClient);
 
       return new FaunaClient(builder.build());
@@ -94,7 +94,7 @@ public class FaunaClient implements AutoCloseable {
   private final ObjectMapper json = new ObjectMapper().registerModule(new GuavaModule());
   private final Connection connection;
 
-  public FaunaClient(Connection connection) {
+  private FaunaClient(Connection connection) {
     this.connection = connection;
   }
 

--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -148,7 +148,7 @@ public class FaunaClient implements AutoCloseable {
    * Frees any resources held by the client. Also closes the underlying {@link Connection}.
    */
   @Override
-  public void close() throws IOException {
+  public void close() {
     connection.close();
   }
 

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -803,7 +803,7 @@ public class ClientSpec extends FaunaDBTest {
 
     String secret = auth.at("secret").to(STRING).get();
 
-    try (FaunaClient sessionClient = createFaunaClient(secret)) {
+    try (FaunaClient sessionClient = client.newSessionClient(secret)) {
       Value loggedOut = sessionClient.query(Logout(Value(true))).get();
       assertThat(loggedOut.to(BOOLEAN).get(), is(true));
     }

--- a/faunadb-java/src/test/java/com/faunadb/client/test/FaunaDBTest.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/test/FaunaDBTest.java
@@ -3,7 +3,6 @@ package com.faunadb.client.test;
 import com.faunadb.client.FaunaClient;
 import com.faunadb.client.types.Value;
 import com.faunadb.client.types.Value.RefV;
-import com.faunadb.common.Connection;
 import com.google.common.base.Function;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -50,12 +49,10 @@ public class FaunaDBTest {
 
   protected static FaunaClient createFaunaClient(String secret) {
     try {
-      return FaunaClient.create(
-        Connection.builder()
-          .withFaunaRoot(ROOT_URL)
-          .withAuthToken(secret)
-          .build()
-      );
+      return FaunaClient.builder()
+        .withEndpoint(ROOT_URL)
+        .withSecret(secret)
+        .build();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/faunadb-java/src/test/java/com/faunadb/client/test/FaunaDBTest.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/test/FaunaDBTest.java
@@ -6,6 +6,7 @@ import com.faunadb.client.types.Value.RefV;
 import com.google.common.base.Function;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.ListenableFuture;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.util.Random;
@@ -45,6 +46,12 @@ public class FaunaDBTest {
       transformAsync(createDatabase(), createServerKey()),
       createClientWithServerKey()
     ).get();
+  }
+
+  @AfterClass
+  public static void closeClients() throws Exception {
+    rootClient.close();
+    client.close();
   }
 
   protected static FaunaClient createFaunaClient(String secret) {

--- a/faunadb-java/src/test/java/com/faunadb/client/test/FaunaDBTest.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/test/FaunaDBTest.java
@@ -23,9 +23,7 @@ public class FaunaDBTest {
   private static final String ROOT_TOKEN;
   private static final String ROOT_URL;
 
-  protected static FaunaClient rootClient;
   protected static FaunaClient client;
-  protected static String dbName;
 
   static {
     ROOT_TOKEN = EnvVariables.require("FAUNA_ROOT_KEY");
@@ -39,18 +37,21 @@ public class FaunaDBTest {
 
   @BeforeClass
   public static void setUpClient() throws Exception {
-    dbName = format("faunadb-java-test-%s", new Random().nextLong());
-    rootClient = createFaunaClient(ROOT_TOKEN);
+    String dbName = format("faunadb-java-test-%s", new Random().nextLong());
 
-    client = transform(
-      transformAsync(createDatabase(), createServerKey()),
-      createClientWithServerKey()
-    ).get();
+    try (FaunaClient rootClient = createFaunaClient(ROOT_TOKEN)) {
+      client = transform(
+        transformAsync(
+          createDatabase(rootClient, dbName),
+          createServerKey(rootClient)
+        ),
+        createClientWithServerKey(rootClient)
+      ).get();
+    }
   }
 
   @AfterClass
   public static void closeClients() throws Exception {
-    rootClient.close();
     client.close();
   }
 
@@ -65,7 +66,7 @@ public class FaunaDBTest {
     }
   }
 
-  private static ListenableFuture<Value> createDatabase() {
+  private static ListenableFuture<Value> createDatabase(FaunaClient rootClient, String dbName) {
     return rootClient.query(
       Create(
         Ref("databases"),
@@ -74,7 +75,7 @@ public class FaunaDBTest {
     );
   }
 
-  private static AsyncFunction<Value, Value> createServerKey() {
+  private static AsyncFunction<Value, Value> createServerKey(final FaunaClient rootClient) {
     return new AsyncFunction<Value, Value>() {
       @Override
       public ListenableFuture<Value> apply(Value dbCreateR) throws Exception {
@@ -91,12 +92,12 @@ public class FaunaDBTest {
     };
   }
 
-  private static Function<Value, FaunaClient> createClientWithServerKey() {
+  private static Function<Value, FaunaClient> createClientWithServerKey(final FaunaClient rootClient) {
     return new Function<Value, FaunaClient>() {
       @Override
       public FaunaClient apply(Value serverKeyF) {
         String secret = serverKeyF.at("secret").to(STRING).get();
-        return createFaunaClient(secret);
+        return rootClient.newSessionClient(secret);
       }
     };
   }


### PR DESCRIPTION
Major changes:
- Removing unnecessary exceptions from the `Connection.Builder` API
- Introducing API for short live connection sharing underneath resources
- Creating a builder for `FaunaClient` so we have a less verbose way to construct them

Minor:
- Renaming some variables and constants to conform to java conventions
- Do not create strings for debugging if debug level is disabled