### PR TITLE
Making Value constructor private

### DIFF
--- a/faunadb-java/src/main/java/com/faunadb/client/types/Value.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/Value.java
@@ -66,6 +66,9 @@ import static java.util.Objects.requireNonNull;
 @JsonDeserialize(using = Deserializer.ValueDeserializer.class)
 public abstract class Value extends Expr {
 
+  private Value() {
+  }
+
   /**
    * Attempts to coerce this value using the {@link Codec} passed
    *


### PR DESCRIPTION
At the moment, I see no reason why custom values should be allowed
considering that they will not be covered by the value deserialization
mechanism.

Codec interface should be the most idiomatic way to create custom value
conversions.