### PR TITLE
Adding high precision time API

### DIFF
--- a/faunadb-java/src/main/java/com/faunadb/client/query/Language.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/query/Language.java
@@ -2,6 +2,7 @@ package com.faunadb.client.query;
 
 import com.faunadb.client.types.Value;
 import com.faunadb.client.types.Value.*;
+import com.faunadb.client.types.time.HighPrecisionTime;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.Instant;
@@ -211,6 +212,10 @@ public final class Language {
    * @see <a href="https://faunadb.com/documentation/queries#values">FaunaDB Values</a>
    */
   public static Expr Value(Instant value) {
+    return new TimeV(new HighPrecisionTime(value, 0, 0));
+  }
+
+  public static Expr Value(HighPrecisionTime value) {
     return new TimeV(value);
   }
 

--- a/faunadb-java/src/main/java/com/faunadb/client/query/Language.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/query/Language.java
@@ -215,6 +215,12 @@ public final class Language {
     return new TimeV(new HighPrecisionTime(value, 0, 0));
   }
 
+  /**
+   * Creates a new Timestamp value from a high precision time.
+   *
+   * @see <a href="https://faunadb.com/documentation/queries#values">FaunaDB Values</a>
+   * @see HighPrecisionTime
+   */
   public static Expr Value(HighPrecisionTime value) {
     return new TimeV(value);
   }

--- a/faunadb-java/src/main/java/com/faunadb/client/types/Codec.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/Codec.java
@@ -84,7 +84,7 @@ public interface Codec<T> extends Function<Value, Result<T>> {
   Codec<Instant> TIME = Cast.mapTo(TimeV.class, new Function<TimeV, Instant>() {
     @Override
     public Instant apply(TimeV time) {
-      return time.truncaded();
+      return time.truncated();
     }
   });
 

--- a/faunadb-java/src/main/java/com/faunadb/client/types/Codec.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/Codec.java
@@ -88,6 +88,9 @@ public interface Codec<T> extends Function<Value, Result<T>> {
     }
   });
 
+  /**
+   * Coerce a {@link Value} to an {@link HighPrecisionTime}
+   */
   Codec<HighPrecisionTime> HP_TIME = Cast.mapTo(TimeV.class, Cast.<TimeV, HighPrecisionTime>scalarValue());
 
   /**

--- a/faunadb-java/src/main/java/com/faunadb/client/types/Codec.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/Codec.java
@@ -1,6 +1,7 @@
 package com.faunadb.client.types;
 
 import com.faunadb.client.types.Value.*;
+import com.faunadb.client.types.time.HighPrecisionTime;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableList;
@@ -80,7 +81,14 @@ public interface Codec<T> extends Function<Value, Result<T>> {
   /**
    * Coerce a {@link Value} to an {@link Instant}
    */
-  Codec<Instant> TIME = Cast.mapTo(TimeV.class, Cast.<TimeV, Instant>scalarValue());
+  Codec<Instant> TIME = Cast.mapTo(TimeV.class, new Function<TimeV, Instant>() {
+    @Override
+    public Instant apply(TimeV time) {
+      return time.truncaded();
+    }
+  });
+
+  Codec<HighPrecisionTime> HP_TIME = Cast.mapTo(TimeV.class, Cast.<TimeV, HighPrecisionTime>scalarValue());
 
   /**
    * Coerce a {@link Value} to a {@link String}

--- a/faunadb-java/src/main/java/com/faunadb/client/types/Value.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/Value.java
@@ -378,13 +378,13 @@ public abstract class Value extends Expr {
    */
   public static final class TimeV extends ScalarValue<HighPrecisionTime> {
 
-    public TimeV(Instant value) {
-      super(new HighPrecisionTime(value, 0, 0));
+    public TimeV(HighPrecisionTime value) {
+      super(value);
     }
 
     @JsonCreator
     private TimeV(@JsonProperty("@ts") String value) {
-      super(HighPrecisionTime.parse(value));
+      this(HighPrecisionTime.parse(value));
     }
 
     Instant truncaded() {

--- a/faunadb-java/src/main/java/com/faunadb/client/types/Value.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/Value.java
@@ -379,7 +379,7 @@ public abstract class Value extends Expr {
    */
   public static final class TimeV extends ScalarValue<Instant> {
 
-    private static final DateTimeFormatter TIME_FORMAT = ISODateTimeFormat.dateTimeNoMillis();
+    private static final DateTimeFormatter TIME_FORMAT = ISODateTimeFormat.dateTimeParser();
 
     public TimeV(Instant value) {
       super(value);

--- a/faunadb-java/src/main/java/com/faunadb/client/types/Value.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/Value.java
@@ -388,7 +388,7 @@ public abstract class Value extends Expr {
     }
 
     Instant truncaded() {
-      return value.truncated();
+      return value.toInstant();
     }
 
     @Override

--- a/faunadb-java/src/main/java/com/faunadb/client/types/Value.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/Value.java
@@ -8,13 +8,12 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.faunadb.client.query.Expr;
 import com.faunadb.client.query.Language;
+import com.faunadb.client.types.time.HighPrecisionTime;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.Instant;
 import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 
 import java.util.List;
 import java.util.Map;
@@ -377,23 +376,25 @@ public abstract class Value extends Expr {
    *
    * @see Language#Value(Instant)
    */
-  public static final class TimeV extends ScalarValue<Instant> {
-
-    private static final DateTimeFormatter TIME_FORMAT = ISODateTimeFormat.dateTimeParser();
+  public static final class TimeV extends ScalarValue<HighPrecisionTime> {
 
     public TimeV(Instant value) {
-      super(value);
+      super(new HighPrecisionTime(value, 0, 0));
     }
 
     @JsonCreator
     private TimeV(@JsonProperty("@ts") String value) {
-      super(TIME_FORMAT.parseDateTime(value).toInstant());
+      super(HighPrecisionTime.parse(value));
+    }
+
+    Instant truncaded() {
+      return value.truncated();
     }
 
     @Override
     @JsonProperty("@ts")
     protected String toJson() {
-      return value.toString(TIME_FORMAT);
+      return value.toString();
     }
 
   }

--- a/faunadb-java/src/main/java/com/faunadb/client/types/Value.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/Value.java
@@ -387,7 +387,7 @@ public abstract class Value extends Expr {
       this(HighPrecisionTime.parse(value));
     }
 
-    Instant truncaded() {
+    Instant truncated() {
       return value.toInstant();
     }
 

--- a/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
@@ -1,0 +1,75 @@
+package com.faunadb.client.types.time;
+
+import org.joda.time.Instant;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.Objects.hash;
+import static java.util.Objects.requireNonNull;
+
+public class HighPrecisionTime {
+
+  private static final Pattern PRECISION_GROUPS = Pattern.compile("\\.\\d{3}(?<micros>\\d{3})(?<nanos>\\d{3})?Z");
+  private static final DateTimeFormatter TIME_PARSER = ISODateTimeFormat.dateTimeParser();
+  private static final DateTimeFormatter TIME_FORMAT = ISODateTimeFormat.dateTimeNoMillis();
+
+  public static HighPrecisionTime parse(String value) {
+    Instant initialTime = TIME_PARSER.parseDateTime(value).toInstant();
+    Matcher precision = PRECISION_GROUPS.matcher(value);
+
+    if (precision.find()) {
+      String micros = precision.group("micros");
+      String nanos = precision.group("nanos");
+
+      return new HighPrecisionTime(initialTime, Long.valueOf(micros), nanos != null ? Long.valueOf(nanos) : 0);
+    }
+
+    return new HighPrecisionTime(initialTime, 0, 0);
+  }
+
+  public static HighPrecisionTime microSeconds(long micro) {
+    return new HighPrecisionTime(new Instant(0), micro, 0);
+  }
+
+  public static HighPrecisionTime nanoSeconds(long nano) {
+    return new HighPrecisionTime(new Instant(0), 0, nano);
+  }
+
+  private final Instant initialTime;
+  private final long microsToAdd;
+  private final long nanosToAdd;
+
+  public HighPrecisionTime(Instant initialTime, long microsToAdd, long nanosToAdd) {
+    this.initialTime = requireNonNull(initialTime);
+    this.microsToAdd = microsToAdd;
+    this.nanosToAdd = nanosToAdd;
+  }
+
+  public Instant truncated() {
+    return initialTime;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof HighPrecisionTime))
+      return false;
+
+    HighPrecisionTime other = (HighPrecisionTime) obj;
+    return this.initialTime.equals(other.initialTime)
+      && this.microsToAdd == other.microsToAdd
+      && this.nanosToAdd == other.nanosToAdd;
+  }
+
+  @Override
+  public int hashCode() {
+    return hash(initialTime, microsToAdd, nanosToAdd);
+  }
+
+  @Override
+  public String toString() {
+    return initialTime.toString(TIME_FORMAT);
+  }
+}

--- a/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
@@ -10,10 +10,19 @@ import static java.lang.String.format;
 import static java.util.Objects.hash;
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Wraps an instance of {@link Instant} and adds micro nano second precision to it.
+ */
 public class HighPrecisionTime {
 
   private static final Pattern PRECISION_GROUPS = Pattern.compile("\\.\\d{3}(?<micros>\\d{3})(?<nanos>\\d{3})?Z");
 
+  /**
+   * Parses a string into a {@link HighPrecisionTime} instance.
+   *
+   * @param value string formated as yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZ
+   * @return an new instance of {@link HighPrecisionTime}
+   */
   public static HighPrecisionTime parse(String value) {
     Instant initialTime = ISODateTimeFormat.dateTimeParser().parseDateTime(value).toInstant();
     Matcher precision = PRECISION_GROUPS.matcher(value);
@@ -37,6 +46,20 @@ public class HighPrecisionTime {
   private final long microsToAdd;
   private final long nanosToAdd;
 
+  /**
+   * Creates a new instance of {@link HighPrecisionTime}. Nano and micro seconds overflows will
+   * be calculated and added to the initial timestamp.
+   * <p>
+   * For example:
+   * <ul>
+   *   <li>{@code new HighPrecisionTime(new Instant(0), 1001, 0) == new HighPrecisionTime(new Instant(1), 1, 0)}</li>
+   *   <li>{@code new HighPrecisionTime(new Instant(0), 0, 1001) == new HighPrecisionTime(new Instant(0), 1, 1)}</li>
+   * </ul>
+   *
+   * @param initialTime initial timestamp
+   * @param microsToAdd micro seconds to add to the initial timestamp
+   * @param nanosToAdd  nano seconds to add to the initial timestamp
+   */
   public HighPrecisionTime(Instant initialTime, long microsToAdd, long nanosToAdd) {
     requireNonNull(initialTime);
     long microsOverflow = microsToAdd + nanosToAdd / 1000;
@@ -46,14 +69,31 @@ public class HighPrecisionTime {
     this.nanosToAdd = nanosToAdd % 1000;
   }
 
+  /**
+   * Returns an instance of {@link Instant} without micro and nano seconds.
+   *
+   * @return trucated timestamp
+   */
   public Instant toInstant() {
     return truncated;
   }
 
+  /**
+   * Returns the number of micro seconds remaining to be added to the underlying timestamp.
+   *
+   * @return number of micro seconds
+   * @see HighPrecisionTime#HighPrecisionTime(Instant, long, long)
+   */
   public long getMicros() {
     return microsToAdd;
   }
 
+  /**
+   * Returns the number of nano seconds remaining to be added to the underlying timestamp.
+   *
+   * @return number of nano seconds
+   * @see HighPrecisionTime#HighPrecisionTime(Instant, long, long)
+   */
   public long getNamos() {
     return nanosToAdd;
   }

--- a/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
@@ -13,7 +13,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Wraps an instance of {@link Instant} and adds micro and nanosecond precision to it.
  */
-public class HighPrecisionTime {
+public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
 
   private static final Pattern PRECISION_GROUPS = Pattern.compile("\\.\\d{3}(?<micros>\\d{3})(?<nanos>\\d{3})?Z");
 
@@ -120,6 +120,16 @@ public class HighPrecisionTime {
   @Override
   public int hashCode() {
     return hash(truncated, nanosToAdd);
+  }
+
+  @Override
+  public int compareTo(HighPrecisionTime other) {
+    int compareTruncated = truncated.compareTo(other.truncated);
+    if (compareTruncated != 0) return compareTruncated;
+
+    if (nanosToAdd < other.nanosToAdd) return -1;
+    if (nanosToAdd > other.nanosToAdd) return 1;
+    return 0;
   }
 
   @Override

--- a/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
@@ -46,8 +46,16 @@ public class HighPrecisionTime {
     this.nanosToAdd = nanosToAdd % 1000;
   }
 
-  public Instant truncated() {
+  public Instant toInstant() {
     return truncated;
+  }
+
+  public long getMicros() {
+    return microsToAdd;
+  }
+
+  public long getNamos() {
+    return nanosToAdd;
   }
 
   @Override

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -772,6 +772,7 @@ public class ClientSpec extends FaunaDBTest {
   @Test
   public void shouldEvalEpochExpression() throws Exception {
     Value res = client.query(Epoch(Value(30), SECOND)).get();
+
     assertThat(res.to(TIME).get(), equalTo(new Instant(0).plus(Duration.standardSeconds(30))));
   }
 

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -794,13 +794,15 @@ public class ClientSpec extends FaunaDBTest {
 
     HighPrecisionTime micros = res.get(0).to(HP_TIME).get();
     assertThat(micros.toInstant(), equalTo(new Instant(1)));
-    assertThat(micros.getMicros(), equalTo(1L));
-    assertThat(micros.getNamos(), equalTo(0L));
+    assertThat(micros.toMillis(), equalTo(1L));
+    assertThat(micros.remainingMicros(), equalTo(1));
+    assertThat(micros.remainingNanos(), equalTo(1000));
 
     HighPrecisionTime nanos = res.get(1).to(HP_TIME).get();
     assertThat(nanos.toInstant(), equalTo(new Instant(0)));
-    assertThat(nanos.getMicros(), equalTo(1L));
-    assertThat(nanos.getNamos(), equalTo(1L));
+    assertThat(nanos.toMillis(), equalTo(0L));
+    assertThat(nanos.remainingMicros(), equalTo(1));
+    assertThat(nanos.remainingNanos(), equalTo(1001));
   }
 
   @Test

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -786,6 +786,24 @@ public class ClientSpec extends FaunaDBTest {
   }
 
   @Test
+  public void shouldOverflowOnHighPrecisionTime() throws Exception {
+    ImmutableList<Value> res = client.query(ImmutableList.of(
+      Epoch(Value(1001), MICROSECOND),
+      Epoch(Value(1001), NANOSECOND)
+    )).get();
+
+    HighPrecisionTime micros = res.get(0).to(HP_TIME).get();
+    assertThat(micros.toInstant(), equalTo(new Instant(1)));
+    assertThat(micros.getMicros(), equalTo(1L));
+    assertThat(micros.getNamos(), equalTo(0L));
+
+    HighPrecisionTime nanos = res.get(1).to(HP_TIME).get();
+    assertThat(nanos.toInstant(), equalTo(new Instant(0)));
+    assertThat(nanos.getMicros(), equalTo(1L));
+    assertThat(nanos.getNamos(), equalTo(1L));
+  }
+
+  @Test
   public void shouldEvalDateExpression() throws Exception {
     Value res = client.query(Date(Value("1970-01-02"))).get();
     assertThat(res.to(DATE).get(), equalTo(new LocalDate(0, UTC).plusDays(1)));

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -10,6 +10,7 @@ import com.faunadb.client.types.Value;
 import com.faunadb.client.types.Value.ObjectV;
 import com.faunadb.client.types.Value.RefV;
 import com.faunadb.client.types.Value.StringV;
+import com.faunadb.client.types.time.HighPrecisionTime;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -26,7 +27,7 @@ import java.util.Random;
 import static com.faunadb.client.query.Language.Action.CREATE;
 import static com.faunadb.client.query.Language.Action.DELETE;
 import static com.faunadb.client.query.Language.*;
-import static com.faunadb.client.query.Language.TimeUnit.SECOND;
+import static com.faunadb.client.query.Language.TimeUnit.*;
 import static com.faunadb.client.types.Codec.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
@@ -771,9 +772,17 @@ public class ClientSpec extends FaunaDBTest {
 
   @Test
   public void shouldEvalEpochExpression() throws Exception {
-    Value res = client.query(Epoch(Value(30), SECOND)).get();
+    ImmutableList<Value> res = client.query(ImmutableList.of(
+      Epoch(Value(30), SECOND),
+      Epoch(Value(30), MILLISECOND),
+      Epoch(Value(30), MICROSECOND),
+      Epoch(Value(30), NANOSECOND)
+    )).get();
 
-    assertThat(res.to(TIME).get(), equalTo(new Instant(0).plus(Duration.standardSeconds(30))));
+    assertThat(res.get(0).to(TIME).get(), equalTo(new Instant(0).plus(Duration.standardSeconds(30))));
+    assertThat(res.get(1).to(TIME).get(), equalTo(new Instant(0).plus(Duration.millis(30))));
+    assertThat(res.get(2).to(HP_TIME).get(), equalTo(new HighPrecisionTime(new Instant(0), 30, 0)));
+    assertThat(res.get(3).to(HP_TIME).get(), equalTo(new HighPrecisionTime(new Instant(0), 0, 30)));
   }
 
   @Test

--- a/faunadb-java/src/test/java/com/faunadb/client/DeserializationSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/DeserializationSpec.java
@@ -100,10 +100,10 @@ public class DeserializationSpec {
   @Test
   public void shouldDeserializeHighPrecisionTime() throws Exception {
     HighPrecisionTime micro = parsed("{ \"@ts\": \"1970-01-01T00:00:00.000005Z\" }").to(HP_TIME).get();
-    assertThat(micro, equalTo(HighPrecisionTime.microSeconds(5)));
+    assertThat(micro, equalTo(new HighPrecisionTime(new Instant(0), 5, 0)));
 
     HighPrecisionTime nano = parsed("{ \"@ts\": \"1970-01-01T00:00:00.000000005Z\" }").to(HP_TIME).get();
-    assertThat(nano, equalTo(HighPrecisionTime.nanoSeconds(5)));
+    assertThat(nano, equalTo(new HighPrecisionTime(new Instant(0), 0, 5)));
   }
 
   @Test

--- a/faunadb-java/src/test/java/com/faunadb/client/DeserializationSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/DeserializationSpec.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.faunadb.client.types.Value;
 import com.faunadb.client.types.Value.RefV;
+import com.faunadb.client.types.time.HighPrecisionTime;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.Duration;
@@ -94,6 +95,15 @@ public class DeserializationSpec {
 
     assertThat(parsed("{ \"@ts\": \"1970-01-01T00:00:00.00000005Z\" }").to(TIME).get(),
       equalTo(new Instant(0)));
+  }
+
+  @Test
+  public void shouldDeserializeHighPrecisionTime() throws Exception {
+    HighPrecisionTime micro = parsed("{ \"@ts\": \"1970-01-01T00:00:00.000005Z\" }").to(HP_TIME).get();
+    assertThat(micro, equalTo(HighPrecisionTime.microSeconds(5)));
+
+    HighPrecisionTime nano = parsed("{ \"@ts\": \"1970-01-01T00:00:00.000000005Z\" }").to(HP_TIME).get();
+    assertThat(nano, equalTo(HighPrecisionTime.nanoSeconds(5)));
   }
 
   @Test

--- a/faunadb-java/src/test/java/com/faunadb/client/DeserializationSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/DeserializationSpec.java
@@ -76,9 +76,24 @@ public class DeserializationSpec {
   }
 
   @Test
-  public void shouldDeserializeTS() throws IOException {
+  public void shouldDeserializeTime() throws IOException {
     assertThat(parsed("{ \"@ts\": \"1970-01-01T00:05:00Z\" }").to(TIME).get(),
       equalTo(new Instant(0).plus(Duration.standardMinutes(5))));
+
+    assertThat(parsed("{ \"@ts\": \"1970-01-01T00:00:05Z\" }").to(TIME).get(),
+      equalTo(new Instant(0).plus(Duration.standardSeconds(5))));
+
+    assertThat(parsed("{ \"@ts\": \"1970-01-01T00:00:00.005Z\" }").to(TIME).get(),
+      equalTo(new Instant(5)));
+  }
+
+  @Test
+  public void shouldIgnoreHightPrecisionWhenConvertingToTime() throws IOException {
+    assertThat(parsed("{ \"@ts\": \"1970-01-01T00:00:00.000005Z\" }").to(TIME).get(),
+      equalTo(new Instant(0)));
+
+    assertThat(parsed("{ \"@ts\": \"1970-01-01T00:00:00.00000005Z\" }").to(TIME).get(),
+      equalTo(new Instant(0)));
   }
 
   @Test

--- a/faunadb-java/src/test/java/com/faunadb/client/SerializationSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/SerializationSpec.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.faunadb.client.query.Expr;
 import com.faunadb.client.types.Value.ObjectV;
 import com.faunadb.client.types.Value.StringV;
+import com.faunadb.client.types.time.HighPrecisionTime;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.joda.time.Duration;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -128,7 +130,26 @@ public class SerializationSpec {
 
   @Test
   public void shouldSerializeInstantValue() throws Exception {
-    assertJson(Value(new Instant(0)), "{\"@ts\":\"1970-01-01T00:00:00Z\"}");
+    assertJson(Value(new Instant(0)), "{\"@ts\":\"1970-01-01T00:00:00.000000000Z\"}");
+  }
+
+  @Test
+  public void shouldSerializeHighPrecisionTimeValue() throws Exception {
+    Instant initialTime = new Instant(10)
+      .plus(Duration.standardMinutes(5))
+      .plus(Duration.standardSeconds(2));
+
+    assertJson(Value(new HighPrecisionTime(initialTime, 0, 0)),
+      "{\"@ts\":\"1970-01-01T00:05:02.010000000Z\"}");
+
+    assertJson(Value(new HighPrecisionTime(initialTime, 20, 5)),
+      "{\"@ts\":\"1970-01-01T00:05:02.010020005Z\"}");
+
+    assertJson(Value(new HighPrecisionTime(initialTime, 1001, 5)),
+      "{\"@ts\":\"1970-01-01T00:05:02.011001005Z\"}");
+
+    assertJson(Value(new HighPrecisionTime(initialTime, 20, 1001)),
+      "{\"@ts\":\"1970-01-01T00:05:02.010021001Z\"}");
   }
 
   @Test
@@ -370,7 +391,7 @@ public class SerializationSpec {
 
     assertJson(
       Exists(Ref("classes/spells/104979509692858368"), Value(new Instant(0))),
-      "{\"exists\":{\"@ref\":\"classes/spells/104979509692858368\"},\"ts\":{\"@ts\":\"1970-01-01T00:00:00Z\"}}"
+      "{\"exists\":{\"@ref\":\"classes/spells/104979509692858368\"},\"ts\":{\"@ts\":\"1970-01-01T00:00:00.000000000Z\"}}"
     );
   }
 
@@ -436,7 +457,7 @@ public class SerializationSpec {
         Action.CREATE,
         Obj("data", Obj("name", Value("test")))
       ),
-      "{\"insert\":{\"@ref\":\"classes/spells/104979509696660483\"},\"ts\":{\"@ts\":\"1970-01-01T00:00:00Z\"}," +
+      "{\"insert\":{\"@ref\":\"classes/spells/104979509696660483\"},\"ts\":{\"@ts\":\"1970-01-01T00:00:00.000000000Z\"}," +
         "\"action\":\"create\",\"params\":{\"object\":{\"data\":{\"object\":{\"name\":\"test\"}}}}}"
     );
 
@@ -447,7 +468,7 @@ public class SerializationSpec {
         Value("create"),
         Obj("data", Obj("name", Value("test")))
       ),
-      "{\"insert\":{\"@ref\":\"classes/spells/104979509696660483\"},\"ts\":{\"@ts\":\"1970-01-01T00:00:00Z\"}," +
+      "{\"insert\":{\"@ref\":\"classes/spells/104979509696660483\"},\"ts\":{\"@ts\":\"1970-01-01T00:00:00.000000000Z\"}," +
         "\"action\":\"create\",\"params\":{\"object\":{\"data\":{\"object\":{\"name\":\"test\"}}}}}"
     );
   }
@@ -461,7 +482,7 @@ public class SerializationSpec {
         Action.DELETE
       ),
       "{\"remove\":{\"@ref\":\"classes/spells/104979509696660483\"}," +
-        "\"ts\":{\"@ts\":\"1970-01-01T00:00:00Z\"},\"action\":\"delete\"}"
+        "\"ts\":{\"@ts\":\"1970-01-01T00:00:00.000000000Z\"},\"action\":\"delete\"}"
     );
 
     assertJson(
@@ -471,7 +492,7 @@ public class SerializationSpec {
         Value("delete")
       ),
       "{\"remove\":{\"@ref\":\"classes/spells/104979509696660483\"}," +
-        "\"ts\":{\"@ts\":\"1970-01-01T00:00:00Z\"},\"action\":\"delete\"}"
+        "\"ts\":{\"@ts\":\"1970-01-01T00:00:00.000000000Z\"},\"action\":\"delete\"}"
     );
   }
 


### PR DESCRIPTION
This implementation handles high precision time representations as neither Java 7 or JodaTime classes supports micro and nano second precision.