### PR TITLE
Using long to represent time on the Java driver

### DIFF
--- a/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
@@ -30,20 +30,20 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
     if (precision.find()) {
       return new HighPrecisionTime(
         initialTime,
-        toInt(precision.group("micros")),
-        toInt(precision.group("nanos"))
+        toLong(precision.group("micros")),
+        toLong(precision.group("nanos"))
       );
     }
 
     return new HighPrecisionTime(initialTime, 0, 0);
   }
 
-  private static int toInt(String value) {
-    return value != null ? Integer.valueOf(value) : 0;
+  private static long toLong(String value) {
+    return value != null ? Long.valueOf(value) : 0;
   }
 
   private final Instant truncated;
-  private final int nanosToAdd;
+  private final long nanosToAdd;
 
   /**
    * Creates a new instance of {@link HighPrecisionTime}. Nano and microseconds overflows will
@@ -59,9 +59,9 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
    * @param microsToAdd microseconds to add to the initial timestamp
    * @param nanosToAdd  nanoseconds to add to the initial timestamp
    */
-  public HighPrecisionTime(Instant initialTime, int microsToAdd, int nanosToAdd) {
+  public HighPrecisionTime(Instant initialTime, long microsToAdd, long nanosToAdd) {
     requireNonNull(initialTime);
-    int microsOverflow = microsToAdd + nanosToAdd / 1000;
+    long microsOverflow = microsToAdd + nanosToAdd / 1000;
     this.truncated = initialTime.plus(microsOverflow / 1000);
     this.nanosToAdd = (microsOverflow % 1000) * 1000 + nanosToAdd % 1000;
   }
@@ -80,7 +80,7 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
    * Truncates nanoseconds, if any.
    *
    * @return number of milliseconds
-   * @see HighPrecisionTime#HighPrecisionTime(Instant, int, int)
+   * @see HighPrecisionTime#HighPrecisionTime(Instant, long, long)
    */
   public long toMillis() {
     return truncated.getMillis();
@@ -91,9 +91,9 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
    * Truncates nanoseconds, if any.
    *
    * @return number of microseconds
-   * @see HighPrecisionTime#HighPrecisionTime(Instant, int, int)
+   * @see HighPrecisionTime#HighPrecisionTime(Instant, long, long)
    */
-  public int remainingMicros() {
+  public long remainingMicros() {
     return nanosToAdd / 1000;
   }
 
@@ -101,9 +101,9 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
    * Returns the number of nanoseconds remaining to be added to the underlying timestamp.
    *
    * @return number of nanoseconds
-   * @see HighPrecisionTime#HighPrecisionTime(Instant, int, int)
+   * @see HighPrecisionTime#HighPrecisionTime(Instant, long, long)
    */
-  public int remainingNanos() {
+  public long remainingNanos() {
     return nanosToAdd;
   }
 

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -797,14 +797,14 @@ public class ClientSpec extends FaunaDBTest {
     HighPrecisionTime micros = res.get(0).to(HP_TIME).get();
     assertThat(micros.toInstant(), equalTo(new Instant(1)));
     assertThat(micros.toMillis(), equalTo(1L));
-    assertThat(micros.remainingMicros(), equalTo(1));
-    assertThat(micros.remainingNanos(), equalTo(1000));
+    assertThat(micros.remainingMicros(), equalTo(1L));
+    assertThat(micros.remainingNanos(), equalTo(1000L));
 
     HighPrecisionTime nanos = res.get(1).to(HP_TIME).get();
     assertThat(nanos.toInstant(), equalTo(new Instant(0)));
     assertThat(nanos.toMillis(), equalTo(0L));
-    assertThat(nanos.remainingMicros(), equalTo(1));
-    assertThat(nanos.remainingNanos(), equalTo(1001));
+    assertThat(nanos.remainingMicros(), equalTo(1L));
+    assertThat(nanos.remainingNanos(), equalTo(1001L));
   }
 
   @Test


### PR DESCRIPTION
So people can use `System.nanoTime()` easily.