### PR TITLE
Refactor java time

### DIFF
--- a/faunadb-java/src/main/java/com/faunadb/client/query/Language.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/query/Language.java
@@ -212,7 +212,7 @@ public final class Language {
    * @see <a href="https://faunadb.com/documentation/queries#values">FaunaDB Values</a>
    */
   public static Expr Value(Instant value) {
-    return new TimeV(HighPrecisionTime.fromInstant(value, 0, 0));
+    return new TimeV(HighPrecisionTime.fromInstant(value));
   }
 
   /**

--- a/faunadb-java/src/main/java/com/faunadb/client/query/Language.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/query/Language.java
@@ -212,7 +212,7 @@ public final class Language {
    * @see <a href="https://faunadb.com/documentation/queries#values">FaunaDB Values</a>
    */
   public static Expr Value(Instant value) {
-    return new TimeV(new HighPrecisionTime(value, 0, 0));
+    return new TimeV(HighPrecisionTime.fromInstant(value, 0, 0));
   }
 
   /**

--- a/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
@@ -136,8 +136,7 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
   @Override
   public int compareTo(HighPrecisionTime other) {
     int compareSeconds = Long.compare(secondsSinceEpoch, other.secondsSinceEpoch);
-    if (compareSeconds != 0)
-      return compareSeconds;
+    if (compareSeconds != 0) return compareSeconds;
 
     return Integer.compare(nanoSecondsOffset, other.nanoSecondsOffset);
   }

--- a/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
@@ -30,20 +30,20 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
     if (precision.find()) {
       return new HighPrecisionTime(
         initialTime,
-        toInt(precision.group("micros")),
-        toInt(precision.group("nanos"))
+        toLong(precision.group("micros")),
+        toLong(precision.group("nanos"))
       );
     }
 
     return new HighPrecisionTime(initialTime, 0, 0);
   }
 
-  private static int toInt(String value) {
-    return value != null ? Integer.valueOf(value) : 0;
+  private static long toLong(String value) {
+    return value != null ? Long.valueOf(value) : 0;
   }
 
   private final Instant truncated;
-  private final int nanosToAdd;
+  private final long nanosToAdd;
 
   /**
    * Creates a new instance of {@link HighPrecisionTime}. Nano and microseconds overflows will
@@ -59,9 +59,9 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
    * @param microsToAdd microseconds to add to the initial timestamp
    * @param nanosToAdd  nanoseconds to add to the initial timestamp
    */
-  public HighPrecisionTime(Instant initialTime, int microsToAdd, int nanosToAdd) {
+  public HighPrecisionTime(Instant initialTime, long microsToAdd, long nanosToAdd) {
     requireNonNull(initialTime);
-    int microsOverflow = microsToAdd + nanosToAdd / 1000;
+    long microsOverflow = microsToAdd + nanosToAdd / 1000;
     this.truncated = initialTime.plus(microsOverflow / 1000);
     this.nanosToAdd = (microsOverflow % 1000) * 1000 + nanosToAdd % 1000;
   }
@@ -80,7 +80,7 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
    * Truncates nanoseconds, if any.
    *
    * @return number of milliseconds
-   * @see HighPrecisionTime#HighPrecisionTime(Instant, int, int)
+   * @see HighPrecisionTime#HighPrecisionTime(Instant, long, long)
    */
   public long toMillis() {
     return truncated.getMillis();
@@ -91,9 +91,9 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
    * Truncates nanoseconds, if any.
    *
    * @return number of microseconds
-   * @see HighPrecisionTime#HighPrecisionTime(Instant, int, int)
+   * @see HighPrecisionTime#HighPrecisionTime(Instant, long, long)
    */
-  public int remainingMicros() {
+  public long remainingMicros() {
     return nanosToAdd / 1000;
   }
 
@@ -101,9 +101,9 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
    * Returns the number of nanoseconds remaining to be added to the underlying timestamp.
    *
    * @return number of nanoseconds
-   * @see HighPrecisionTime#HighPrecisionTime(Instant, int, int)
+   * @see HighPrecisionTime#HighPrecisionTime(Instant, long, long)
    */
-  public int remainingNanos() {
+  public long remainingNanos() {
     return nanosToAdd;
   }
 

--- a/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
@@ -68,7 +68,7 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
    * @param initialTime initial timestamp
    * @param nanosToAdd  nanoseconds to add to the initial timestamp
    */
-  public static HighPrecisionTime withNanos(Instant initialTime, long nanosToAdd) {
+  public static HighPrecisionTime fromInstantWithNanos(Instant initialTime, long nanosToAdd) {
     return create(initialTime, 0, nanosToAdd);
   }
 
@@ -84,7 +84,7 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
    * @param initialTime initial timestamp
    * @param microsToAdd  nanoseconds to add to the initial timestamp
    */
-  public static HighPrecisionTime withMicros(Instant initialTime, long microsToAdd) {
+  public static HighPrecisionTime fromInstantWithMicros(Instant initialTime, long microsToAdd) {
     return create(initialTime, microsToAdd, 0);
   }
 

--- a/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/time/HighPrecisionTime.java
@@ -15,7 +15,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
 
-  private static final int NANOS_IN_A_MIRO = 1000;
+  private static final int NANOS_IN_A_MICRO = 1000;
   private static final int NANOS_IN_A_MILLI = 1000000;
   private static final int NANOS_IN_A_SECOND = 1000000000;
   private static final int MILLIS_IN_A_SECOND = 1000;
@@ -62,7 +62,7 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
    * <p>
    * For example:
    * <pre>
-   * {@code HighPrecisionTime.withNanos(new Instant(1), 0) == HighPrecisionTime.withNanos(new Instant(0), 1000000)}
+   * {@code HighPrecisionTime.fromInstantWithNanos(new Instant(1), 0) == HighPrecisionTime.fromInstantWithNanos(new Instant(0), 1000000)}
    * </pre>
    *
    * @param initialTime initial timestamp
@@ -78,7 +78,7 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
    * <p>
    * For example:
    * <pre>
-   * {@code HighPrecisionTime.fromInstant(new Instant(1), 0) == HighPrecisionTime.fromInstant(new Instant(0), 1000)}
+   * {@code HighPrecisionTime.fromInstantWithMicros(new Instant(1), 0) == HighPrecisionTime.fromInstantWithMicros(new Instant(0), 1000)}
    * </pre>
    *
    * @param initialTime initial timestamp
@@ -93,7 +93,7 @@ public class HighPrecisionTime implements Comparable<HighPrecisionTime> {
 
     long nanos =
       initialTime.getMillis() % MILLIS_IN_A_SECOND * NANOS_IN_A_MILLI +
-        microsToAdd * NANOS_IN_A_MIRO +
+        microsToAdd * NANOS_IN_A_MICRO +
         nanosToAdd;
 
     return new HighPrecisionTime(initialTime.getMillis() / MILLIS_IN_A_SECOND, nanos);

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -783,8 +783,8 @@ public class ClientSpec extends FaunaDBTest {
 
     assertThat(res.get(0).to(TIME).get(), equalTo(new Instant(0).plus(Duration.standardSeconds(30))));
     assertThat(res.get(1).to(TIME).get(), equalTo(new Instant(0).plus(Duration.millis(30))));
-    assertThat(res.get(2).to(HP_TIME).get(), equalTo(HighPrecisionTime.withMicros(new Instant(0), 30)));
-    assertThat(res.get(3).to(HP_TIME).get(), equalTo(HighPrecisionTime.withNanos(new Instant(0), 30)));
+    assertThat(res.get(2).to(HP_TIME).get(), equalTo(HighPrecisionTime.fromInstantWithMicros(new Instant(0), 30)));
+    assertThat(res.get(3).to(HP_TIME).get(), equalTo(HighPrecisionTime.fromInstantWithNanos(new Instant(0), 30)));
   }
 
   @Test
@@ -818,8 +818,8 @@ public class ClientSpec extends FaunaDBTest {
     Arrays.sort(times);
 
     assertThat(times, arrayContaining(
-      HighPrecisionTime.withNanos(new Instant(0), 42),
-      HighPrecisionTime.withMicros(new Instant(0), 30),
+      HighPrecisionTime.fromInstantWithNanos(new Instant(0), 42),
+      HighPrecisionTime.fromInstantWithMicros(new Instant(0), 30),
       HighPrecisionTime.fromInstant(new Instant(50)),
       HighPrecisionTime.fromInstant(new Instant(1000))
     ));

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -783,8 +783,8 @@ public class ClientSpec extends FaunaDBTest {
 
     assertThat(res.get(0).to(TIME).get(), equalTo(new Instant(0).plus(Duration.standardSeconds(30))));
     assertThat(res.get(1).to(TIME).get(), equalTo(new Instant(0).plus(Duration.millis(30))));
-    assertThat(res.get(2).to(HP_TIME).get(), equalTo(new HighPrecisionTime(new Instant(0), 30, 0)));
-    assertThat(res.get(3).to(HP_TIME).get(), equalTo(new HighPrecisionTime(new Instant(0), 0, 30)));
+    assertThat(res.get(2).to(HP_TIME).get(), equalTo(HighPrecisionTime.fromInstant(new Instant(0), 30, 0)));
+    assertThat(res.get(3).to(HP_TIME).get(), equalTo(HighPrecisionTime.fromInstant(new Instant(0), 0, 30)));
   }
 
   @Test
@@ -796,15 +796,13 @@ public class ClientSpec extends FaunaDBTest {
 
     HighPrecisionTime micros = res.get(0).to(HP_TIME).get();
     assertThat(micros.toInstant(), equalTo(new Instant(1)));
-    assertThat(micros.toMillis(), equalTo(1L));
-    assertThat(micros.remainingMicros(), equalTo(1L));
-    assertThat(micros.remainingNanos(), equalTo(1000L));
+    assertThat(micros.getMillisecondsFromEpoch(), equalTo(1L));
+    assertThat(micros.getNanosecondsOffset(), equalTo(1001000L));
 
     HighPrecisionTime nanos = res.get(1).to(HP_TIME).get();
     assertThat(nanos.toInstant(), equalTo(new Instant(0)));
-    assertThat(nanos.toMillis(), equalTo(0L));
-    assertThat(nanos.remainingMicros(), equalTo(1L));
-    assertThat(nanos.remainingNanos(), equalTo(1001L));
+    assertThat(nanos.getMillisecondsFromEpoch(), equalTo(0L));
+    assertThat(nanos.getNanosecondsOffset(), equalTo(1001L));
   }
 
   @Test
@@ -820,10 +818,10 @@ public class ClientSpec extends FaunaDBTest {
     Arrays.sort(times);
 
     assertThat(times, arrayContaining(
-      new HighPrecisionTime(new Instant(0), 0, 42),
-      new HighPrecisionTime(new Instant(0), 30, 0),
-      new HighPrecisionTime(new Instant(50), 0, 0),
-      new HighPrecisionTime(new Instant(1000), 0, 0)
+      HighPrecisionTime.fromInstant(new Instant(0), 0, 42),
+      HighPrecisionTime.fromInstant(new Instant(0), 30, 0),
+      HighPrecisionTime.fromInstant(new Instant(50), 0, 0),
+      HighPrecisionTime.fromInstant(new Instant(1000), 0, 0)
     ));
   }
 

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -783,8 +783,8 @@ public class ClientSpec extends FaunaDBTest {
 
     assertThat(res.get(0).to(TIME).get(), equalTo(new Instant(0).plus(Duration.standardSeconds(30))));
     assertThat(res.get(1).to(TIME).get(), equalTo(new Instant(0).plus(Duration.millis(30))));
-    assertThat(res.get(2).to(HP_TIME).get(), equalTo(HighPrecisionTime.fromInstant(new Instant(0), 30, 0)));
-    assertThat(res.get(3).to(HP_TIME).get(), equalTo(HighPrecisionTime.fromInstant(new Instant(0), 0, 30)));
+    assertThat(res.get(2).to(HP_TIME).get(), equalTo(HighPrecisionTime.withMicros(new Instant(0), 30)));
+    assertThat(res.get(3).to(HP_TIME).get(), equalTo(HighPrecisionTime.withNanos(new Instant(0), 30)));
   }
 
   @Test
@@ -818,10 +818,10 @@ public class ClientSpec extends FaunaDBTest {
     Arrays.sort(times);
 
     assertThat(times, arrayContaining(
-      HighPrecisionTime.fromInstant(new Instant(0), 0, 42),
-      HighPrecisionTime.fromInstant(new Instant(0), 30, 0),
-      HighPrecisionTime.fromInstant(new Instant(50), 0, 0),
-      HighPrecisionTime.fromInstant(new Instant(1000), 0, 0)
+      HighPrecisionTime.withNanos(new Instant(0), 42),
+      HighPrecisionTime.withMicros(new Instant(0), 30),
+      HighPrecisionTime.fromInstant(new Instant(50)),
+      HighPrecisionTime.fromInstant(new Instant(1000))
     ));
   }
 

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -797,14 +797,14 @@ public class ClientSpec extends FaunaDBTest {
     HighPrecisionTime micros = res.get(0).to(HP_TIME).get();
     assertThat(micros.toInstant(), equalTo(new Instant(1)));
     assertThat(micros.toMillis(), equalTo(1L));
-    assertThat(micros.remainingMicros(), equalTo(1));
-    assertThat(micros.remainingNanos(), equalTo(1000));
+    assertThat(micros.remainingMicros(), equalTo(1L));
+    assertThat(micros.remainingNanos(), equalTo(1000L));
 
     HighPrecisionTime nanos = res.get(1).to(HP_TIME).get();
     assertThat(nanos.toInstant(), equalTo(new Instant(0)));
     assertThat(nanos.toMillis(), equalTo(0L));
-    assertThat(nanos.remainingMicros(), equalTo(1));
-    assertThat(nanos.remainingNanos(), equalTo(1001));
+    assertThat(nanos.remainingMicros(), equalTo(1L));
+    assertThat(nanos.remainingNanos(), equalTo(1001L));
   }
 
   @Test

--- a/faunadb-java/src/test/java/com/faunadb/client/DeserializationSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/DeserializationSpec.java
@@ -100,10 +100,10 @@ public class DeserializationSpec {
   @Test
   public void shouldDeserializeHighPrecisionTime() throws Exception {
     HighPrecisionTime micro = parsed("{ \"@ts\": \"1970-01-01T00:00:00.000005Z\" }").to(HP_TIME).get();
-    assertThat(micro, equalTo(new HighPrecisionTime(new Instant(0), 5, 0)));
+    assertThat(micro, equalTo(new HighPrecisionTime(0, 5000)));
 
     HighPrecisionTime nano = parsed("{ \"@ts\": \"1970-01-01T00:00:00.000000005Z\" }").to(HP_TIME).get();
-    assertThat(nano, equalTo(new HighPrecisionTime(new Instant(0), 0, 5)));
+    assertThat(nano, equalTo(new HighPrecisionTime(0, 5)));
   }
 
   @Test

--- a/faunadb-java/src/test/java/com/faunadb/client/SerializationSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/SerializationSpec.java
@@ -139,17 +139,17 @@ public class SerializationSpec {
       .plus(Duration.standardMinutes(5))
       .plus(Duration.standardSeconds(2));
 
-    assertJson(Value(HighPrecisionTime.fromInstant(initialTime, 0, 0)),
+    assertJson(Value(HighPrecisionTime.fromInstant(initialTime)),
       "{\"@ts\":\"1970-01-01T00:05:02.010000000Z\"}");
 
-    assertJson(Value(HighPrecisionTime.fromInstant(initialTime, 20, 5)),
+    assertJson(Value(HighPrecisionTime.withMicros(initialTime, 1005)),
+      "{\"@ts\":\"1970-01-01T00:05:02.011005000Z\"}");
+
+    assertJson(Value(HighPrecisionTime.withNanos(initialTime, 20005)),
       "{\"@ts\":\"1970-01-01T00:05:02.010020005Z\"}");
 
-    assertJson(Value(HighPrecisionTime.fromInstant(initialTime, 1001, 5)),
-      "{\"@ts\":\"1970-01-01T00:05:02.011001005Z\"}");
-
-    assertJson(Value(HighPrecisionTime.fromInstant(initialTime, 20, 1001)),
-      "{\"@ts\":\"1970-01-01T00:05:02.010021001Z\"}");
+    assertJson(Value(HighPrecisionTime.withNanos(initialTime, 3021001)),
+      "{\"@ts\":\"1970-01-01T00:05:02.013021001Z\"}");
   }
 
   @Test

--- a/faunadb-java/src/test/java/com/faunadb/client/SerializationSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/SerializationSpec.java
@@ -139,16 +139,16 @@ public class SerializationSpec {
       .plus(Duration.standardMinutes(5))
       .plus(Duration.standardSeconds(2));
 
-    assertJson(Value(new HighPrecisionTime(initialTime, 0, 0)),
+    assertJson(Value(HighPrecisionTime.fromInstant(initialTime, 0, 0)),
       "{\"@ts\":\"1970-01-01T00:05:02.010000000Z\"}");
 
-    assertJson(Value(new HighPrecisionTime(initialTime, 20, 5)),
+    assertJson(Value(HighPrecisionTime.fromInstant(initialTime, 20, 5)),
       "{\"@ts\":\"1970-01-01T00:05:02.010020005Z\"}");
 
-    assertJson(Value(new HighPrecisionTime(initialTime, 1001, 5)),
+    assertJson(Value(HighPrecisionTime.fromInstant(initialTime, 1001, 5)),
       "{\"@ts\":\"1970-01-01T00:05:02.011001005Z\"}");
 
-    assertJson(Value(new HighPrecisionTime(initialTime, 20, 1001)),
+    assertJson(Value(HighPrecisionTime.fromInstant(initialTime, 20, 1001)),
       "{\"@ts\":\"1970-01-01T00:05:02.010021001Z\"}");
   }
 

--- a/faunadb-java/src/test/java/com/faunadb/client/SerializationSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/SerializationSpec.java
@@ -142,13 +142,13 @@ public class SerializationSpec {
     assertJson(Value(HighPrecisionTime.fromInstant(initialTime)),
       "{\"@ts\":\"1970-01-01T00:05:02.010000000Z\"}");
 
-    assertJson(Value(HighPrecisionTime.withMicros(initialTime, 1005)),
+    assertJson(Value(HighPrecisionTime.fromInstantWithMicros(initialTime, 1005)),
       "{\"@ts\":\"1970-01-01T00:05:02.011005000Z\"}");
 
-    assertJson(Value(HighPrecisionTime.withNanos(initialTime, 20005)),
+    assertJson(Value(HighPrecisionTime.fromInstantWithNanos(initialTime, 20005)),
       "{\"@ts\":\"1970-01-01T00:05:02.010020005Z\"}");
 
-    assertJson(Value(HighPrecisionTime.withNanos(initialTime, 3021001)),
+    assertJson(Value(HighPrecisionTime.fromInstantWithNanos(initialTime, 3021001)),
       "{\"@ts\":\"1970-01-01T00:05:02.013021001Z\"}");
   }
 


### PR DESCRIPTION
Reimplement `HighPrecisionTime` to use the same internal structure as it's implementation in Scala by #60.