### PR TITLE
Add badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # FaunaDB JVM Drivers
 
+[![Build Status](https://img.shields.io/travis/faunadb/faunadb-jvm/master.svg?maxAge=21600)](https://travis-ci.org/faunadb/faunadb-jvm)
+[![Maven Central](https://img.shields.io/maven-central/v/com.faunadb/faunadb-common.svg?maxAge=21600)]()
+[![License](https://img.shields.io/badge/license-MPL_2.0-blue.svg?maxAge=2592000)](https://raw.githubusercontent.com/faunadb/faunadb-jvm/master/LICENSE)
+
 This repository contains the FaunaDB drivers for the JVM languages. Currently, Java and Scala drivers are implemented.
 
 ### Features


### PR DESCRIPTION
Part of https://github.com/faunadb/sales-engineering/issues/268.

Since I didn't want a badge for each of the 3 artifacts, I tied it to `faunadb-common` for the maven central badge.